### PR TITLE
Moved hideSoftKeyboard method from ConsentSignatureStepLayout into Fo…

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
@@ -1,10 +1,13 @@
 package org.researchstack.backbone.ui.step.body;
 
+import android.app.Activity;
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.LinearLayout;
 
 import org.researchstack.backbone.R;
@@ -24,6 +27,7 @@ public class FormBody implements StepBody {
     //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
     private FormStep step;
     private StepResult<StepResult> result;
+    private ViewGroup parent;
 
     //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
     // View Fields
@@ -37,6 +41,7 @@ public class FormBody implements StepBody {
 
     @Override
     public View getBodyView(int viewType, LayoutInflater inflater, ViewGroup parent) {
+        this.parent = parent;
         // Inflate our container for each compact child StepBody
         LinearLayout body = (LinearLayout) inflater.inflate(R.layout.rsb_step_layout_form_body,
                 parent,
@@ -66,7 +71,6 @@ public class FormBody implements StepBody {
                 result.setResultForIdentifier(childResult.getIdentifier(), childResult);
             }
         }
-
         return result;
     }
 
@@ -78,6 +82,8 @@ public class FormBody implements StepBody {
                 return bodyAnswer;
             }
         }
+
+        hideSoftKeyboard();
 
         return BodyAnswer.VALID;
     }
@@ -94,6 +100,16 @@ public class FormBody implements StepBody {
         } catch (Exception e) {
             LogExt.e(this.getClass(), "Cannot instantiate step body for step " + questionStep.getStepTitle() + ", class name: " + cls.getCanonicalName());
             throw new RuntimeException(e);
+        }
+    }
+
+    private void hideSoftKeyboard() {
+        try {
+            InputMethodManager imm = (InputMethodManager) parent.getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(parent.getRootView().getWindowToken(), 0);
+            parent.getRootView().clearFocus();
+        } catch (NullPointerException e) {
+            Log.e("CSSL", "NPE: " + e.getMessage());
         }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
@@ -1,13 +1,9 @@
 package org.researchstack.backbone.ui.step.body;
 
-import android.app.Activity;
-import android.content.Context;
 import android.support.annotation.NonNull;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.LinearLayout;
 
 import org.researchstack.backbone.R;
@@ -16,6 +12,7 @@ import org.researchstack.backbone.step.FormStep;
 import org.researchstack.backbone.step.QuestionStep;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.utils.LogExt;
+import org.researchstack.backbone.utils.ViewUtils;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -83,7 +80,7 @@ public class FormBody implements StepBody {
             }
         }
 
-        hideSoftKeyboard();
+        ViewUtils.hideSoftInputMethod(parent);
 
         return BodyAnswer.VALID;
     }
@@ -93,25 +90,12 @@ public class FormBody implements StepBody {
         StepResult childResult = result.getResultForIdentifier(questionStep.getIdentifier());
 
         Class cls = questionStep.getStepBodyClass();
-        Log.d("FormBody", "cls: " + cls.getName());
         try {
             Constructor constructor = cls.getConstructor(Step.class, StepResult.class);
             return (StepBody) constructor.newInstance(questionStep, childResult);
         } catch (Exception e) {
             LogExt.e(this.getClass(), "Cannot instantiate step body for step " + questionStep.getStepTitle() + ", class name: " + cls.getCanonicalName());
             throw new RuntimeException(e);
-        }
-    }
-
-    private void hideSoftKeyboard() {
-        try {
-            InputMethodManager imm = (InputMethodManager) parent.getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
-            if (imm != null) {
-                imm.hideSoftInputFromWindow(parent.getWindowToken(), 0);
-                parent.clearFocus();
-            }
-        } catch (NullPointerException e) {
-            Log.e("CSSL", "NPE: " + e.getMessage());
         }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
@@ -106,8 +106,10 @@ public class FormBody implements StepBody {
     private void hideSoftKeyboard() {
         try {
             InputMethodManager imm = (InputMethodManager) parent.getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
-            imm.hideSoftInputFromWindow(parent.getRootView().getWindowToken(), 0);
-            parent.getRootView().clearFocus();
+            if (imm != null) {
+                imm.hideSoftInputFromWindow(parent.getWindowToken(), 0);
+                parent.clearFocus();
+            }
         } catch (NullPointerException e) {
             Log.e("CSSL", "NPE: " + e.getMessage());
         }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -1,20 +1,15 @@
 package org.researchstack.backbone.ui.step.layout;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.support.v7.widget.AppCompatTextView;
 import android.util.AttributeSet;
 import android.util.Base64;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
-
-import com.jakewharton.rxbinding.view.RxView;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.result.StepResult;
@@ -40,29 +35,23 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
     private StepCallbacks callbacks;
     private Step step;
     private StepResult<String> result;
-    private Context context;
 
     public ConsentSignatureStepLayout(Context context) {
         super(context);
-        this.context = context;
     }
 
     public ConsentSignatureStepLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
-        this.context = context;
     }
 
     public ConsentSignatureStepLayout(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        this.context = context;
     }
 
     @Override
     public void initialize(Step step, StepResult result) {
         this.step = step;
         this.result = result == null ? new StepResult<>(step) : result;
-
-        hideSoftKeyboard();
 
         initializeStep();
     }
@@ -168,16 +157,6 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
             return Base64.encodeToString(byteArray, Base64.DEFAULT);
         } else {
             return null;
-        }
-    }
-
-    private void hideSoftKeyboard() {
-        try {
-            InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
-            imm.hideSoftInputFromWindow(getRootView().getWindowToken(), 0);
-            getRootView().clearFocus();
-        } catch (NullPointerException e) {
-            Log.e("CSSL", "NPE: " + e.getMessage());
         }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/utils/ViewUtils.java
+++ b/backbone/src/main/java/org/researchstack/backbone/utils/ViewUtils.java
@@ -6,7 +6,9 @@ import android.os.Build;
 import android.support.v4.app.Fragment;
 import android.text.InputFilter;
 import android.text.InputType;
+import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
@@ -58,6 +60,18 @@ public class ViewUtils {
                 InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
                 imm.hideSoftInputFromInputMethod(currentFocus.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
             }
+        }
+    }
+
+    public static void hideSoftInputMethod(ViewGroup parent) {
+        try {
+            InputMethodManager imm = (InputMethodManager) parent.getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
+            if (imm != null) {
+                imm.hideSoftInputFromWindow(parent.getWindowToken(), 0);
+                parent.clearFocus();
+            }
+        } catch (NullPointerException e) {
+            Log.e("CSSL", "NPE: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
…rmBody

The keyboard has to be hidden before entering the ConsentSignatureStep or it will remain visible once we get there. There are no keyboard-focussable views in the signature step so the keyboard will not be shown again once at that step.