### PR TITLE
PAT-407: Boolean Step: The next button of the boolean steps is not displayed when it has a custom string property and the previous step is a text step

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/FixedSubmitBarLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/FixedSubmitBarLayout.java
@@ -79,8 +79,7 @@ public abstract class FixedSubmitBarLayout extends FrameLayout implements StepLa
         if (guidePosition <= yLimit) {
             ViewCompat.setTranslationY(submitBar, 0);
         } else {
-            int translationY = guidePosition - yLimit;
-            ViewCompat.setTranslationY(submitBar, translationY);
+            ViewCompat.setTranslationY(submitBar, 0);
         }
 
     }


### PR DESCRIPTION
Sometimes, the "Next" button is not displayed in a boolean step. This is so, because the "submitBar"  view which contains the next button is moved to a wrong Y position, so the button completely disappears

JIRA ticket is https://jira.devops.medable.com/browse/PAT-407
I'm not sure about why `guidePosition` and `yLimit` were needed here, but they are the reason of this issue (causing next button to be hidden)

I'm not removing them completely from the code, until we make sure everything works as expected
