### PR TITLE
Minor Toolchain Upgrade

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 android {
 
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     libraryVariants.all { variant ->
@@ -64,7 +64,7 @@ dependencies {
     implementation 'co.touchlab.squeaky:squeaky-query:0.4.0.0'
     annotationProcessor 'co.touchlab.squeaky:squeaky-processor:0.4.0.0'
     implementation 'net.zetetic:android-database-sqlcipher:3.5.4@aar'
-    implementation 'com.afollestad.material-dialogs:core:0.9.0.2'
+    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.0'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.3.0"
     }
@@ -49,10 +49,10 @@ android {
 }
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:27.1.0'
-    implementation 'com.android.support:cardview-v7:27.1.0'
-    implementation 'com.android.support:preference-v14:27.1.0'
-    implementation 'com.android.support:design:27.1.0'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:cardview-v7:27.1.1'
+    implementation 'com.android.support:preference-v14:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
     implementation 'com.google.code.gson:gson:2.4'
     implementation 'io.reactivex:rxjava:1.1.3'
     implementation 'io.reactivex:rxandroid:1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
     dependencies {
         // change this to 1.5.x if you're not on Android Studio 2.0.0 beta
-        classpath "com.android.tools.build:gradle:$rootProject.ext.gradlePluginVersion"
+        classpath "com.android.tools.build:gradle:3.3.2"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "com.neenbedankt.gradle.plugins:android-apt:1.4"


### PR DESCRIPTION
## Objective
* Minor tech_debt that we can get out of the way to pave the road for a future migration to Androidx and latest libraries; it's now impossible to migrate to `androidx` support libraries due to the multiple old-dependencies we still carry; this is a _very small_ step forwards. We can compile with API 28, as long as we're targeting API 27 (can't upgrade to 28 yet).
* Update the support libraries (27.1.0 to 27.1.1).
* Do not use the root project ext variables for critical versioning, since this prevents the individual project from being individually assembled (outside of PAT) which kind of defeats the purpose of having separate projects to begin with. ;)
