### PR TITLE
Compile ResearchStack with API 27.

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 android {
 
-    compileSdkVersion 28
+    compileSdkVersion 27
     buildToolsVersion '28.0.3'
 
     libraryVariants.all { variant ->

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,6 @@ buildscript {
         google()
     }
 
-    project.ext {
-        gradlePluginVersion = '3.0.1'
-    }
-
     dependencies {
         // change this to 1.5.x if you're not on Android Studio 2.0.0 beta
         classpath "com.android.tools.build:gradle:3.3.2"


### PR DESCRIPTION
Fix C.I. issues with API 28. Downgrade to API 27 for both compile and target.