### PR TITLE
PAT-611: Fix form question options UI

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/FixedSubmitBarLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/FixedSubmitBarLayout.java
@@ -1,15 +1,12 @@
 package org.researchstack.backbone.ui.views;
 
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.support.v4.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
-import android.widget.ScrollView;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ui.step.layout.StepLayout;
@@ -30,12 +27,6 @@ public abstract class FixedSubmitBarLayout extends FrameLayout implements StepLa
         init();
     }
 
-    @TargetApi(21)
-    public FixedSubmitBarLayout(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
-        init();
-    }
-
     public abstract int getContentResourceId();
 
     private void init() {
@@ -44,15 +35,15 @@ public abstract class FixedSubmitBarLayout extends FrameLayout implements StepLa
         inflater.inflate(R.layout.rsb_layout_fixed_submit_bar, this, true);
 
         // Add contentContainer to the layout
-        ViewGroup contentContainer = (ViewGroup) findViewById(R.id.rsb_content_container);
+        ViewGroup contentContainer = findViewById(R.id.rsb_content_container);
         View content = inflater.inflate(getContentResourceId(), contentContainer, false);
         contentContainer.addView(content, 0);
 
         // Init scrollview and submit bar guide positioning
         final View submitBarGuide = findViewById(R.id.rsb_submit_bar_guide);
-        final SubmitBar submitBar = (SubmitBar) findViewById(R.id.rsb_submit_bar);
-        ObservableScrollView scrollView = (ObservableScrollView) findViewById(R.id.rsb_content_container_scrollview);
-        scrollView.setScrollListener(scrollY -> onScrollChanged(scrollView, submitBarGuide, submitBar));
+        final SubmitBar submitBar = findViewById(R.id.rsb_submit_bar);
+        ObservableScrollView scrollView = findViewById(R.id.rsb_content_container_scrollview);
+        scrollView.setScrollListener(scrollY -> submitBar.setTranslationY(0));
         scrollView.getViewTreeObserver()
                 .addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
                     @Override
@@ -65,22 +56,8 @@ public abstract class FixedSubmitBarLayout extends FrameLayout implements StepLa
                             submitBarGuide.requestLayout();
                         }
 
-                        onScrollChanged(scrollView, submitBarGuide, submitBar);
+                        submitBar.setTranslationY(0);
                     }
                 });
-    }
-
-    private void onScrollChanged(ScrollView scrollView, View submitBarGuide, View submitBar) {
-        int scrollY = scrollView.getScrollY();
-        int guidePosition = submitBarGuide.getTop() - scrollY;
-        int guideHeight = submitBarGuide.getHeight();
-        int yLimit = scrollView.getHeight() - guideHeight;
-
-        if (guidePosition <= yLimit) {
-            ViewCompat.setTranslationY(submitBar, 0);
-        } else {
-            ViewCompat.setTranslationY(submitBar, 0);
-        }
-
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/ObservableScrollView.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/ObservableScrollView.java
@@ -1,28 +1,31 @@
 package org.researchstack.backbone.ui.views;
 
-import android.annotation.TargetApi;
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.widget.NestedScrollView;
 import android.util.AttributeSet;
-import android.widget.ScrollView;
 
-public class ObservableScrollView extends ScrollView {
+/**
+ * This extension of a {@link NestedScrollView} exists solely to support API 23<
+ * The only addition is the proxy scroll listener that the original ScrollView didn't have without extending and that
+ * NestedScrollView only offers to API 23+.
+ * This class should be removed once the min API is increased to 23 and callers should use a pure NestedScrollView.
+ */
+public class ObservableScrollView extends NestedScrollView {
+    @Nullable
     private OnScrollListener onScrollListener;
 
-    public ObservableScrollView(Context context) {
+    public ObservableScrollView(@NonNull final Context context) {
         super(context);
     }
 
-    public ObservableScrollView(Context context, AttributeSet attrs) {
+    public ObservableScrollView(@NonNull final Context context, @Nullable final AttributeSet attrs) {
         super(context, attrs);
     }
 
-    public ObservableScrollView(Context context, AttributeSet attrs, int defStyleAttr) {
+    public ObservableScrollView(@NonNull final Context context, @Nullable final AttributeSet attrs, final int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-    }
-
-    @TargetApi(21)
-    public ObservableScrollView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
     }
 
     @Override


### PR DESCRIPTION
### Objective
* Provide a better ScrollView (`NestedScrollView`) instead of the old `ScrollView`.
    * The nested version has a better handling of other nested components (like RecyclerViews) which Backbone uses to present Single/Multiple choice FormSteps.
    * Each FormStep is a list of QuestionStep, which in turn, when needed, instantiate `RSTextChoice[Single|Multiple]Body` instances, depending. These instances contain a TextView label for the title of the question, and a RecyclerView to present each Combo or Radio button, depending whether it's single or multiple.
    * All this is wrapped in a custom `ObservableScrollView` which supports adding a listener to proxy the scroll action callback; this is old, and no longer needed when on API 23, but since we're still targeting API 19, I left it there.
    * Cleanup code in `FixedSubmitBarLayout` because it had unused code. 


### TEST
1. You cannot test this, I will integrate it with Axon in an incoming PR, but this will aid in fixing PAT-611.
