### PR TITLE
PAT-824: SurveyLayout/FormBody: check if fields are optional when validating.

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
@@ -30,6 +30,7 @@ public class FormBody implements StepBody {
     // View Fields
     //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
     private List<StepBody> formStepChildren;
+    private List<QuestionStep> questionSteps;
 
     public FormBody(Step step, StepResult result) {
         this.step = (FormStep) step;
@@ -44,7 +45,7 @@ public class FormBody implements StepBody {
                 parent,
                 false);
 
-        List<QuestionStep> questionSteps = step.getFormSteps();
+        questionSteps = step.getFormSteps();
         formStepChildren = new ArrayList<>(questionSteps.size());
 
         // Iterate through all steps and generate each compact view. Store each StepBody child in a
@@ -97,5 +98,9 @@ public class FormBody implements StepBody {
             LogExt.e(this.getClass(), "Cannot instantiate step body for step " + questionStep.getStepTitle() + ", class name: " + cls.getCanonicalName());
             throw new RuntimeException(e);
         }
+    }
+
+    public List<QuestionStep> getQuestionSteps() {
+        return questionSteps;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -9,7 +9,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.text.Html;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.text.Html;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -23,6 +24,7 @@ import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.ui.ViewWebDocumentActivity;
 import org.researchstack.backbone.ui.callbacks.StepCallbacks;
 import org.researchstack.backbone.ui.step.body.BodyAnswer;
+import org.researchstack.backbone.ui.step.body.FormBody;
 import org.researchstack.backbone.ui.step.body.StepBody;
 import org.researchstack.backbone.ui.views.FixedSubmitBarLayout;
 import org.researchstack.backbone.ui.views.SubmitBar;
@@ -58,6 +60,8 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
     private SubmitBar submitBar;
 
     private MediatorLiveData<Boolean> mediator = new MediatorLiveData<>();
+    private boolean allStepsAreOptional;
+
     public SurveyStepLayout(Context context) {
         super(context);
     }
@@ -208,8 +212,9 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
             container.addView(body, bodyIndex);
             body.setId(R.id.rsb_survey_step_body);
         }
-    }
 
+        checkIfAllStepsAreOptional();
+    }
 
     @NonNull
     private StepBody createStepBody(QuestionStep questionStep, StepResult result) {
@@ -268,11 +273,28 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
     }
 
     private void isStepEmpty(boolean isEmpty) {
-        if (!isEmpty)  {
+        if (!isEmpty || allStepsAreOptional)  {
             submitBar.setPositiveActionEnabled(getStep().getColorSecondary());
         } else {
             submitBar.setPositiveActionDisabled();
         }
 
+    }
+
+    private void checkIfAllStepsAreOptional() {
+        if (stepBody == null || !(stepBody instanceof FormBody)) {
+            return;
+        }
+
+        boolean allStepsAreOptional = true;
+
+        for (final QuestionStep step : ((FormBody) stepBody).getQuestionSteps()) {
+            if (!step.isOptional()) {
+                allStepsAreOptional = false;
+                break;
+            }
+        }
+
+        this.allStepsAreOptional = allStepsAreOptional;
     }
 }


### PR DESCRIPTION
### Objective
* Ensure that a formBody with *all* optional steps, allows you to tap NEXT without any validation interfering.

### How to Test: 
* We need a small Axon Change in backbone, sadly so this needs to be integrated before it can be tested.
* If you still want to give it a try, be my guest:
```
Environment: Test
Org: Hybridstudy
Study: Test Hybrid Study
Task: [FROZEN FOR PAT-824] do not modify
account: franco+2@medable.com qpal1010 
PIN 950181
```

**You must change one line of code in Backbone or this will not work**

In `RSNumericBody.java`, find the line:

```
float entryValue = 0;
```

And replace it with:
```
float entryValue = step.isOptional() && hasMinimum ? step.getMinimumFloat() : 0;
```

This is around line 114 in the `public BodyAnswer getBodyAnswerState() {` method.

The above change is coming in a PR in Axon once this is merged. 
