### PR TITLE
RES-8 Implement Multilanguage in tasks

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentViewTaskActivity.java
@@ -45,11 +45,10 @@ public class ConsentViewTaskActivity extends ViewTaskActivity implements StepCal
     private String lastName;
     private String signatureBase64;
 
-    public static Intent newIntent(Context context, Task task, String assetsFolder, String locale) {
+    public static Intent newIntent(Context context, Task task, String assetsFolder) {
         Intent intent = new Intent(context, ConsentViewTaskActivity.class);
         intent.putExtra(EXTRA_TASK, task);
         intent.putExtra(EXTRA_ASSETS_FOLDER, assetsFolder);
-        preferredLocale = locale;
         return intent;
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentViewTaskActivity.java
@@ -6,7 +6,6 @@ import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
-import android.print.HtmlToPdfPrinter;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -46,11 +45,11 @@ public class ConsentViewTaskActivity extends ViewTaskActivity implements StepCal
     private String lastName;
     private String signatureBase64;
 
-    public static Intent newIntent(Context context, Task task, String assetsFolder) {
+    public static Intent newIntent(Context context, Task task, String assetsFolder, String locale) {
         Intent intent = new Intent(context, ConsentViewTaskActivity.class);
         intent.putExtra(EXTRA_TASK, task);
         intent.putExtra(EXTRA_ASSETS_FOLDER, assetsFolder);
-
+        preferredLocale = locale;
         return intent;
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
@@ -31,20 +31,19 @@ import rx.Observable;
 import rx.functions.Action1;
 
 import static org.researchstack.backbone.utils.LocaleUtils.getLocaleFromString;
+import static org.researchstack.backbone.utils.LocaleUtils.getPreferredLocale;
 import static org.researchstack.backbone.utils.LocaleUtils.wrapLocaleContext;
 
 public class PinCodeActivity extends AppCompatActivity implements StorageAccessListener {
-
-    protected static String preferredLocale = null;
 
     private PinCodeLayout pinCodeLayout;
     private Action1<Boolean> toggleKeyboardAction;
 
     @Override
     protected void attachBaseContext(Context newBase) {
+        String preferredLocale = getPreferredLocale(newBase);
         if (preferredLocale != null) {
             Locale locale = getLocaleFromString(preferredLocale);
-
             super.attachBaseContext(wrapLocaleContext(newBase, locale));
         } else {
             super.attachBaseContext(newBase);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
@@ -25,13 +25,31 @@ import org.researchstack.backbone.utils.ObservableUtils;
 import org.researchstack.backbone.utils.ThemeUtils;
 
 import java.util.List;
+import java.util.Locale;
 
 import rx.Observable;
 import rx.functions.Action1;
 
+import static org.researchstack.backbone.utils.LocaleUtils.getLocaleFromString;
+import static org.researchstack.backbone.utils.LocaleUtils.wrapLocaleContext;
+
 public class PinCodeActivity extends AppCompatActivity implements StorageAccessListener {
+
+    protected static String preferredLocale = null;
+
     private PinCodeLayout pinCodeLayout;
     private Action1<Boolean> toggleKeyboardAction;
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        if (preferredLocale != null) {
+            Locale locale = getLocaleFromString(preferredLocale);
+
+            super.attachBaseContext(wrapLocaleContext(newBase, locale));
+        } else {
+            super.attachBaseContext(newBase);
+        }
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -238,7 +238,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
             ((SurveyStepLayout) stepLayout).initialize(step, result, colorPrimary, colorSecondary, principalTextColor, secondaryTextColor);
             ((SurveyStepLayout) stepLayout).isStepEmpty().observe(this, (isEmpty) -> { });
         } else if (stepLayout instanceof ConsentVisualStepLayout) {
-            ((ConsentVisualStepLayout) stepLayout).initialize(step, result, colorPrimary, colorSecondary, principalTextColor, secondaryTextColor, preferredLocale);
+            ((ConsentVisualStepLayout) stepLayout).initialize(step, result, colorPrimary, colorSecondary, principalTextColor, secondaryTextColor);
         } else {
             stepLayout.initialize(step, result);
         }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -50,6 +50,7 @@ import java.util.List;
 public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, PermissionMediator
 {
     public static final String EXTRA_TASK = "ViewTaskActivity.ExtraTask";
+    public static final String EXTRA_LOCALE= "ViewTaskActivity.ExtraLocale";
     public static final String EXTRA_TASK_RESULT = "ViewTaskActivity.ExtraTaskResult";
     public static final String EXTRA_STEP = "ViewTaskActivity.ExtraStep";
     public static final String EXTRA_COLOR_PRIMARY = "ViewTaskActivity.ExtraColorPrimary";
@@ -77,9 +78,11 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
 
     private int stepCount = 0;
 
-    public static Intent newIntent(Context context, Task task) {
+
+    public static Intent newIntent(Context context, Task task, String locale) {
         Intent intent = new Intent(context, ViewTaskActivity.class);
         intent.putExtra(EXTRA_TASK, task);
+        preferredLocale = locale;
         return intent;
     }
 
@@ -235,7 +238,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
             ((SurveyStepLayout) stepLayout).initialize(step, result, colorPrimary, colorSecondary, principalTextColor, secondaryTextColor);
             ((SurveyStepLayout) stepLayout).isStepEmpty().observe(this, (isEmpty) -> { });
         } else if (stepLayout instanceof ConsentVisualStepLayout) {
-            ((ConsentVisualStepLayout) stepLayout).initialize(step, result, colorPrimary, colorSecondary, principalTextColor, secondaryTextColor);
+            ((ConsentVisualStepLayout) stepLayout).initialize(step, result, colorPrimary, colorSecondary, principalTextColor, secondaryTextColor, preferredLocale);
         } else {
             stepLayout.initialize(step, result);
         }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -50,7 +50,6 @@ import java.util.List;
 public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, PermissionMediator
 {
     public static final String EXTRA_TASK = "ViewTaskActivity.ExtraTask";
-    public static final String EXTRA_LOCALE= "ViewTaskActivity.ExtraLocale";
     public static final String EXTRA_TASK_RESULT = "ViewTaskActivity.ExtraTaskResult";
     public static final String EXTRA_STEP = "ViewTaskActivity.ExtraStep";
     public static final String EXTRA_COLOR_PRIMARY = "ViewTaskActivity.ExtraColorPrimary";
@@ -79,10 +78,9 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
     private int stepCount = 0;
 
 
-    public static Intent newIntent(Context context, Task task, String locale) {
+    public static Intent newIntent(Context context, Task task) {
         Intent intent = new Intent(context, ViewTaskActivity.class);
         intent.putExtra(EXTRA_TASK, task);
-        preferredLocale = locale;
         return intent;
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
+++ b/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
@@ -1,0 +1,37 @@
+package org.researchstack.backbone.utils;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.res.Configuration;
+
+import java.util.Locale;
+
+public class LocaleUtils {
+
+    public static ContextWrapper wrapLocaleContext(Context context, Locale locale) {
+        Configuration config = context.getResources().getConfiguration();
+        Locale.setDefault(locale);
+        config.setLocale(locale);
+        Context newContext = context.createConfigurationContext(config);
+        return new ContextWrapper(newContext);
+    }
+
+    public static Locale getLocaleFromString(String localeString)
+    {
+        String[] parts;
+        if (localeString.contains("_")) {
+            parts = localeString.split("_");
+        } else if (localeString.contains("-")) {
+            parts = localeString.split("-");
+        } else {
+            parts = null;
+        }
+
+        if (parts != null && parts.length > 1) {
+            return new Locale(parts[0], parts[1]);
+        } else {
+            return Locale.getDefault();
+        }
+    }
+
+}

--- a/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
+++ b/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
@@ -2,11 +2,17 @@ package org.researchstack.backbone.utils;
 
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 
 import java.util.Locale;
 
+import static android.content.Context.MODE_PRIVATE;
+
 public class LocaleUtils {
+
+    public static final String LOCALE_PREFERENCES = "LocalePreferences";
+    public static final String PREFERRED_LOCALE_FIELD = "PreferredLocale";
 
     public static ContextWrapper wrapLocaleContext(Context context, Locale locale) {
         Configuration config = context.getResources().getConfiguration();
@@ -34,4 +40,16 @@ public class LocaleUtils {
         }
     }
 
+
+    public static void setPreferredLocale(Context context, String newLocale) {
+        SharedPreferences sharedPrefs = context.getSharedPreferences(LOCALE_PREFERENCES, MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPrefs.edit();
+        editor.putString(PREFERRED_LOCALE_FIELD, newLocale);
+        editor.apply();
+    }
+
+    public static String getPreferredLocale(Context context) {
+        SharedPreferences sharedPrefs = context.getSharedPreferences(LOCALE_PREFERENCES, MODE_PRIVATE);
+        return sharedPrefs.getString(PREFERRED_LOCALE_FIELD, null);
+    }
 }


### PR DESCRIPTION
This brings multilanguage to tasks.
Preferred locale has been saved in shared preferences by Axon. We are retrieving it and set the new Locale in `attachBaseContext`.

To test, please checkout `https://gitlab.medable.com/axon/android/sdk/merge_requests/413` in Axon SDK and `https://gitlab.medable.com/axon/android/app/merge_requests/530` in Patient App

Env: int-dev
Organization: hybridstudy
Study: Multilanguage

* Set your phone to German
* Launch study
* Select Spanish as preferred language
* Login into app (angela+ml4@medable.com / qpal1010)
* Open the boolean task 
* Verify that the task is in spanish