### PR TITLE
PAT-1013: Make sure getString is called with extra args by default.

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
+++ b/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
@@ -44,7 +44,7 @@ public class LocaleUtils {
         String preferredLocale = getPreferredLocale(context);
         if (preferredLocale == null || context.getResources() == null
                 || context.getResources().getConfiguration() == null) {
-            return context.getString(stringId);
+            return context.getString(stringId, args);
         }
         Locale locale = getLocaleFromString(preferredLocale);
         context.getResources().getConfiguration().setLocale(locale);


### PR DESCRIPTION
This MR updates LocaleUtils so args are processed when getLocalizedString is invoked. 