### PR TITLE
PAT-819 Terminate flow if completion step not a trigger and in middle…

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/step/Step.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/Step.java
@@ -43,6 +43,7 @@ public class Step implements Serializable {
     private boolean showsProgress;
     private boolean allowsBackNavigation;
     private boolean useSurveyMode;
+    private boolean completion = false;
 
     /**
      * Returns a new step initialized with the specified identifier.
@@ -102,6 +103,26 @@ public class Step implements Serializable {
      */
     public void setOptional(boolean optional) {
         this.optional = optional;
+    }
+
+    /**
+     * A boolean value indicating whether the flow need to stop after this step is completed.
+     * <p>
+     *
+     * @return a boolean indicating whether the step is the final step of the flow
+     */
+    public boolean isCompletion() {
+        return completion;
+    }
+
+    /**
+     * Sets whether the step is a completion step
+     *
+     * @param completion
+     * @see #isCompletion()
+     */
+    public void setCompletion(boolean completion) {
+        this.completion = completion;
     }
 
     /**

--- a/backbone/src/main/java/org/researchstack/backbone/step/Step.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/Step.java
@@ -43,7 +43,7 @@ public class Step implements Serializable {
     private boolean showsProgress;
     private boolean allowsBackNavigation;
     private boolean useSurveyMode;
-    private boolean completion = false;
+    private boolean isCompletionStep = false;
 
     /**
      * Returns a new step initialized with the specified identifier.
@@ -106,23 +106,26 @@ public class Step implements Serializable {
     }
 
     /**
-     * A boolean value indicating whether the flow need to stop after this step is completed.
+     * A boolean value indicating whether the step is a isCompletionStep step.
+     * If the task is a non branching task, the task need to stop after this step is completed.
+     * If the task is branching, and the isCompletionStep step is the trigger for the branch, then the task shall continue to the next step.
+     * If the task is branching, and the isCompletionStep step is not the trigger for the branch, then task needs to stop.
      * <p>
      *
-     * @return a boolean indicating whether the step is the final step of the flow
+     * @return a boolean indicating whether the step is a isCompletionStep step
      */
-    public boolean isCompletion() {
-        return completion;
+    public boolean isCompletionStep() {
+        return isCompletionStep;
     }
 
     /**
-     * Sets whether the step is a completion step
+     * Sets whether the step is a isCompletionStep step
      *
-     * @param completion
-     * @see #isCompletion()
+     * @param isCompletionStep
+     * @see #isCompletionStep()
      */
-    public void setCompletion(boolean completion) {
-        this.completion = completion;
+    public void isCompletionStep(boolean isCompletionStep) {
+        this.isCompletionStep = isCompletionStep;
     }
 
     /**

--- a/backbone/src/main/java/org/researchstack/backbone/step/Step.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/Step.java
@@ -107,7 +107,7 @@ public class Step implements Serializable {
 
     /**
      * A boolean value indicating whether the step is a isCompletionStep step.
-     * If the task is a non branching task, the task need to stop after this step is completed.
+     * If the task is a non branching task, the task needs to stop after this step is completed.
      * If the task is branching, and the isCompletionStep step is the trigger for the branch, then the task shall continue to the next step.
      * If the task is branching, and the isCompletionStep step is not the trigger for the branch, then task needs to stop.
      * <p>

--- a/backbone/src/main/java/org/researchstack/backbone/step/Step.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/Step.java
@@ -43,7 +43,7 @@ public class Step implements Serializable {
     private boolean showsProgress;
     private boolean allowsBackNavigation;
     private boolean useSurveyMode;
-    private boolean isCompletionStep = false;
+    protected boolean isCompletionStep = false;
 
     /**
      * Returns a new step initialized with the specified identifier.

--- a/backbone/src/main/java/org/researchstack/backbone/task/OrderedTask.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/OrderedTask.java
@@ -67,7 +67,7 @@ public class OrderedTask extends Task implements Serializable {
             return steps.get(0);
         }
 
-        if (step.isCompletion()) {
+        if (step.isCompletionStep()) {
             return null;
         }
 

--- a/backbone/src/main/java/org/researchstack/backbone/task/OrderedTask.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/OrderedTask.java
@@ -67,6 +67,10 @@ public class OrderedTask extends Task implements Serializable {
             return steps.get(0);
         }
 
+        if (step.isCompletion()) {
+            return null;
+        }
+
         int nextIndex = steps.indexOf(step) + 1;
 
         if (nextIndex < steps.size()) {


### PR DESCRIPTION

A completion step in the middle of a task should terminate the task unless it is the trigger of a branching scenario.

### To test:
Check out the following Axon SDK MR:
_https://gitlab.medable.com/axon/android/sdk/merge_requests/425_

- int-dev | hybridstudy | Julien
- julien_bp+1@medable.com | jjulienn

**Scenario 1:** Completion in middle of ordered task (no branching)

- Log into the study, select the task: **Completion second place nobranch**
- Follow steps
- Verify that the task is terminated after Completion task, even though there is another step configured in that task.

**Scenario 2:** Completion in the middle of a branching scenario, and the completion step is the trigger

- Log into the study, select the task: ** Completion branchign **
- Follow steps
- Verify that you are taken to the next step after Competion step, as it is configured as the trigger for the branching.

**Scenario 3:** Completion in the middle of a branching scenario, but is not the trigger

- Log into the study, select the task: ** Branching task but no completion **
- Follow steps
- Verify that the task is terminated after Completion task, even though there is another step configured in that task.
