### PR TITLE
PAT-1094: Migrate to Support Library 28 | Target API 28

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 android {
 
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     libraryVariants.all { variant ->
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.4.0"
     }
@@ -48,23 +48,57 @@ android {
     resourcePrefix 'rsb_'
 }
 dependencies {
+    def supportLibVersion = '28.0.0'
+
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:cardview-v7:27.1.1'
-    implementation 'com.android.support:preference-v14:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.android.support:cardview-v7:$supportLibVersion"
+    implementation "com.android.support:preference-v14:$supportLibVersion"
+    implementation "com.android.support:design:$supportLibVersion"
     implementation 'com.google.code.gson:gson:2.4'
     implementation 'io.reactivex:rxjava:1.1.3'
     implementation 'io.reactivex:rxandroid:1.1.0'
-    implementation 'com.jakewharton.rxbinding:rxbinding:0.2.0'
-    implementation 'com.jakewharton.rxbinding:rxbinding-support-v4:0.2.0'
-    implementation 'com.jakewharton.rxbinding:rxbinding-appcompat-v7:0.2.0'
-    implementation 'com.jakewharton.rxbinding:rxbinding-design:0.2.0'
+    implementation ('com.jakewharton.rxbinding:rxbinding:0.2.0') {
+        exclude group: 'com.android.support', module: 'design'
+        exclude group: 'com.android.support', module: 'animated-vector-drawable'
+        exclude group: 'com.android.support', module: 'support-media-compat'
+        exclude group: 'com.android.support', module: 'appcompat-v7'
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
+    implementation ('com.jakewharton.rxbinding:rxbinding-support-v4:0.2.0') {
+        exclude group: 'com.android.support', module: 'design'
+        exclude group: 'com.android.support', module: 'animated-vector-drawable'
+        exclude group: 'com.android.support', module: 'support-media-compat'
+        exclude group: 'com.android.support', module: 'appcompat-v7'
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
+    implementation ('com.jakewharton.rxbinding:rxbinding-appcompat-v7:0.2.0') {
+        exclude group: 'com.android.support', module: 'design'
+        exclude group: 'com.android.support', module: 'animated-vector-drawable'
+        exclude group: 'com.android.support', module: 'support-media-compat'
+        exclude group: 'com.android.support', module: 'appcompat-v7'
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
+    implementation ('com.jakewharton.rxbinding:rxbinding-design:0.2.0') {
+        exclude group: 'com.android.support', module: 'design'
+        exclude group: 'com.android.support', module: 'animated-vector-drawable'
+        exclude group: 'com.android.support', module: 'support-media-compat'
+        exclude group: 'com.android.support', module: 'appcompat-v7'
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
+
     implementation 'com.scottyab:aes-crypto:0.0.3'
     implementation 'co.touchlab.squeaky:squeaky-query:0.4.0.0'
     annotationProcessor 'co.touchlab.squeaky:squeaky-processor:0.4.0.0'
     implementation 'net.zetetic:android-database-sqlcipher:3.5.4@aar'
-    implementation 'com.afollestad.material-dialogs:core:0.9.0.2'
+    implementation ("com.afollestad.material-dialogs:core:0.9.0.2") {
+        exclude group: 'com.android.support', module: 'design'
+        exclude group: 'com.android.support', module: 'animated-vector-drawable'
+        exclude group: 'com.android.support', module: 'support-media-compat'
+        exclude group: 'com.android.support', module: 'appcompat-v7'
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
+
     implementation "android.arch.lifecycle:extensions:1.1.1"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.0'
@@ -142,6 +176,8 @@ afterEvaluate { project ->
 
 buildscript {
     repositories {
+        google()
+        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -15,11 +15,6 @@ android {
             }
         }
     }
-//    libraryVariants.all { variant ->
-//        variant.outputs.all { output ->
-//            outputFileName = new File(".", output.outputFile.name.replace(".aar", "_v${defaultConfig.versionName}.aar"))
-//        }
-//    }
 
     defaultConfig {
         minSdkVersion 19

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -4,12 +4,22 @@ android {
 
     compileSdkVersion 28
     buildToolsVersion '28.0.3'
+    afterEvaluate {
+        def originalFilePath = "$buildDir/outputs/aar/backbone-release.aar"
+        def newFilePath = originalFilePath.replace(".aar", "_v${defaultConfig.versionName}.aar")
+        def debugFile = file(originalFilePath)
 
-    libraryVariants.all { variant ->
-        variant.outputs.all { output ->
-            outputFileName = new File(".", output.outputFile.name.replace(".aar", "_v${defaultConfig.versionName}.aar"))
+        tasks.named("assembleRelease").configure {
+            doLast {
+                debugFile.renameTo(newFilePath)
+            }
         }
     }
+//    libraryVariants.all { variant ->
+//        variant.outputs.all { output ->
+//            outputFileName = new File(".", output.outputFile.name.replace(".aar", "_v${defaultConfig.versionName}.aar"))
+//        }
+//    }
 
     defaultConfig {
         minSdkVersion 19
@@ -119,7 +129,9 @@ if (project.hasProperty("android")) { // Android libraries
     afterEvaluate {
         javadoc.classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
         javadoc.classpath += files(android.libraryVariants.collect { variant ->
-            variant.javaCompile.classpath.files
+            variant.getJavaCompileProvider().configure {
+                it.classpath.files
+            }
         })
     }
 } else { // Java libraries

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         // change this to 1.5.x if you're not on Android Studio 2.0.0 beta
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "com.neenbedankt.gradle.plugins:android-apt:1.4"

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         // change this to 1.5.x if you're not on Android Studio 2.0.0 beta
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "com.neenbedankt.gradle.plugins:android-apt:1.4"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 05 09:22:29 ART 2017
+#Tue Aug 20 17:15:09 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 20 17:15:09 CEST 2019
+#Wed Aug 21 13:17:30 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
### Objective
* Migrate from Appcompat/Support v27.1.1 to v28.0.0 and Target API 28.

### How to review?
* It's best to observe commit by commit (not the merge ones) to better grasp the important changes.
