### PR TITLE
PAT-1173: Fix Signature Consent App crash when Preferred Locale is changed

### DIFF
--- a/backbone/src/main/res/values-fr-rFR/strings.xml
+++ b/backbone/src/main/res/values-fr-rFR/strings.xml
@@ -148,8 +148,8 @@
     <string name="rsb_error_assetvideoview_button">OK</string>
 
     <!-- Consent -->
-    <string name="rsb_consent_doc_line_printed_name">%1Nom de $s (imprimé)</string>
-    <string name="rsb_consent_doc_line_signature">%1Signature de $s</string>
+    <string name="rsb_consent_doc_line_printed_name">Nom de %1$s (imprimé)</string>
+    <string name="rsb_consent_doc_line_signature">Signature de %1$s</string>
     <string name="rsb_consent_doc_line_date">Date</string>
     <string name="rsb_consent_role">Participant</string>
     <string name="rsb_consent_doc_line_date_format">« MM-jj-aaaa »</string>

--- a/backbone/src/main/res/values-nl-rBE/strings.xml
+++ b/backbone/src/main/res/values-nl-rBE/strings.xml
@@ -148,8 +148,8 @@
     <string name="rsb_error_assetvideoview_button">OK</string>
 
     <!-- Consent -->
-    <string name="rsb_consent_doc_line_printed_name">%1Naam van $s\ (afgedrukt)</string>
-    <string name="rsb_consent_doc_line_signature">%1Handtekening van $s\</string>
+    <string name="rsb_consent_doc_line_printed_name">Naam van %1$s\ (afgedrukt)</string>
+    <string name="rsb_consent_doc_line_signature">Handtekening van %1$s\</string>
     <string name="rsb_consent_doc_line_date">Datum</string>
     <string name="rsb_consent_role">Deelnemer</string>
     <string name="rsb_consent_doc_line_date_format">"MM-dd-jjjj"</string>


### PR DESCRIPTION
Issue: When the user reaches the signature consent step of a consent task, the app crashes when the preferred locale is set to either French (France/fr_FR) or Dutch (Belgium/nl_BE).
 
Context information
- Environment: QA
- Org: Hybridstudy
- Study: Multi-language

How to test:
1- Checkout PAT `rc-4.8.1` branch and go to the context study
2- Select Join Study and set the Locale to either France (Belgium) or Dutch (Belgium) (Test both)
3- Complete the consent task and observe that the App crashes when you complete the signature step
4- Checkout `bug/PAT-1173_fix_consent_signature_app_crash`
5- Clear the App Data
6- Run the App and go over step 2 and 3 and with the same context study
7- The app shouldn't crash for neither fr_FR and nl_BE after the signature step