### PR TITLE
[PAT-731]: Unify Location, Barcode, and Img Capture permission behavior.

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -152,7 +152,6 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
     @Override
     public void requestPermissions(String... permissions) {
         requestPermissions(permissions, STEP_PERMISSION_REQUEST);
-
     }
 
     @Override
@@ -188,7 +187,6 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
             for (final String permission : permissions) {
                 preferences.edit().putBoolean(permission, true).apply();
             }
-
 
             PermissionResult result = new PermissionResult(permissions, grantResults);
             List<PermissionListener> permissionListeners = ViewUtils.findViewsOf(findViewById(android.R.id.content), PermissionListener.class, true);
@@ -255,8 +253,14 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
     }
 
     private void showStep(Step step, boolean isMovingForward) {
-        stepCount += isMovingForward ? 1 : -1;
+        // If the current step is the same, there is no need to recreate anything.
+        if (currentStep != null
+                && currentStepLayout != null
+                && currentStep.getIdentifier().equals(step.getIdentifier())) {
+            return;
+        }
 
+        stepCount += isMovingForward ? 1 : -1;
         currentStepLayout = getLayoutForStep(step);
         currentStepLayout.getLayout().setTag(R.id.rsb_step_layout_id, step.getIdentifier());
         root.show(currentStepLayout, isMovingForward ? StepSwitcher.SHIFT_LEFT : StepSwitcher.SHIFT_RIGHT);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -4,15 +4,12 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.Toolbar;
+import android.preference.PreferenceManager;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -48,8 +45,13 @@ import java.lang.reflect.Constructor;
 import java.util.Date;
 import java.util.List;
 
-public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, PermissionMediator
-{
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.Toolbar;
+
+public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, PermissionMediator {
     public static final String EXTRA_TASK = "ViewTaskActivity.ExtraTask";
     public static final String EXTRA_TASK_RESULT = "ViewTaskActivity.ExtraTaskResult";
     public static final String EXTRA_STEP = "ViewTaskActivity.ExtraStep";
@@ -91,8 +93,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
                                    int colorSecondary,
                                    int principalTextColor,
                                    int secondaryTextColor,
-                                   int actionFailedColor)
-    {
+                                   int actionFailedColor) {
         intent.putExtra(EXTRA_COLOR_PRIMARY, colorPrimary);
         intent.putExtra(EXTRA_COLOR_PRIMARY_DARK, colorPrimaryDark);
         intent.putExtra(EXTRA_COLOR_SECONDARY, colorSecondary);
@@ -107,19 +108,19 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         super.setResult(RESULT_CANCELED);
         super.setContentView(R.layout.rsb_activity_step_switcher);
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
 
-        try
-        {
+        try {
             setSupportActionBar(toolbar);
-        } catch (Exception e)
-        {
+        } catch (Exception e) {
             //there is already an action bar
             toolbar.setVisibility(View.GONE);
         }
 
         actionBar = getSupportActionBar();
-        actionBar.setDisplayHomeAsUpEnabled(false);
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(false);
+        }
 
         root = findViewById(R.id.container);
 
@@ -132,8 +133,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
             secondaryTextColor = getIntent().getIntExtra(EXTRA_SECONDARY_TEXT_COLOR, R.color.rsb_item_text_grey);
             actionFailedColor = getIntent().getIntExtra(EXTRA_ACTION_FAILED_COLOR, R.color.rsb_error);
             taskResult = (TaskResult) getIntent().getExtras().get(EXTRA_TASK_RESULT);
-            if (taskResult == null)
-            {
+            if (taskResult == null) {
                 taskResult = new TaskResult(task.getIdentifier());
             }
             taskResult.setStartDate(new Date());
@@ -148,16 +148,48 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         task.onViewChange(Task.ViewChangeType.ActivityCreate, this, currentStep);
     }
 
-    @RequiresApi(23)
+    @RequiresApi(Build.VERSION_CODES.M)
     @Override
     public void requestPermissions(String... permissions) {
         requestPermissions(permissions, STEP_PERMISSION_REQUEST);
+
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    public boolean checkIfShouldShowRequestPermissionRationale(@NonNull final String permission) {
+
+        // ShouldShowRequestPermissionRationale() will return false in these cases:
+        // * You've never asked for the permission before
+        // * The user has checked the 'never again' checkbox
+        // * The permission has been disabled by policy (usually enterprise)
+        // Therefore a flag must be stored once we requested it.
+        // Source: https://stackoverflow.com/questions/33224432/android-m-anyway-to-know-if-a-user-has-chosen-never-to-show-the-grant-permissi?rq=1
+        // Note: ianhanniballake is a Google employee working on Android (September 2019)
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+        final boolean wasRequestedInThePast = preferences.getBoolean(permission, false);
+        if (!wasRequestedInThePast) {
+            // the user never requested this permission (or we don't have records of it).
+            return true;
+        }
+
+        // If the user requested this permission in the past, we can rely on the rationale flag.
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+                || shouldShowRequestPermissionRationale(permission);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode == STEP_PERMISSION_REQUEST) {
+            // Save the fact that we requested this permission
+            final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+            for (final String permission : permissions) {
+                preferences.edit().putBoolean(permission, true).apply();
+            }
+
+
             PermissionResult result = new PermissionResult(permissions, grantResults);
             List<PermissionListener> permissionListeners = ViewUtils.findViewsOf(findViewById(android.R.id.content), PermissionListener.class, true);
             for (PermissionListener listener : permissionListeners) {
@@ -189,8 +221,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         return currentStep;
     }
 
-    protected String getCurrentTaskId()
-    {
+    protected String getCurrentTaskId() {
         return task.getIdentifier();
     }
 
@@ -199,7 +230,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         if (nextStep == null) {
             saveAndFinish();
         } else {
-            if(nextStep.isHidden()) {
+            if (nextStep.isHidden()) {
                 // We will do the save for this step and then go to the next step
                 processHiddenStep(nextStep);
                 showNextStep();
@@ -214,7 +245,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         if (previousStep == null) {
             finish();
         } else {
-            if(previousStep.isHidden()) {
+            if (previousStep.isHidden()) {
                 // The previous step was a hidden one so we go back again
                 showPreviousStep();
             } else {
@@ -223,21 +254,19 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         }
     }
 
-    private void showStep(Step step, boolean isMovingForward)
-    {
-        stepCount +=  isMovingForward ? 1 : -1;
+    private void showStep(Step step, boolean isMovingForward) {
+        stepCount += isMovingForward ? 1 : -1;
 
         currentStepLayout = getLayoutForStep(step);
         currentStepLayout.getLayout().setTag(R.id.rsb_step_layout_id, step.getIdentifier());
         root.show(currentStepLayout, isMovingForward ? StepSwitcher.SHIFT_LEFT : StepSwitcher.SHIFT_RIGHT);
         actionBar.setDisplayHomeAsUpEnabled(stepCount > 1 && showBackArrow);
         currentStep = step;
-
     }
 
     private void processHiddenStep(Step step) {
-        StepResult result = taskResult.getStepResult(step.getIdentifier()) ;
-        if(result == null) {
+        StepResult result = taskResult.getStepResult(step.getIdentifier());
+        if (result == null) {
             result = new StepResult<>(step);
         }
         result.setResult(step.getHiddenDefaultValue());
@@ -257,10 +286,8 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         // Get result from the TaskResult, can be null
         StepResult result = taskResult.getStepResult(step.getIdentifier());
 
-        if(step instanceof FormStep)
-        {
-            for(QuestionStep questionStep : ((FormStep) step).getFormSteps())
-            {
+        if (step instanceof FormStep) {
+            for (QuestionStep questionStep : ((FormStep) step).getFormSteps()) {
                 questionStep.setStepTheme(step.getPrimaryColor(), step.getColorPrimaryDark(), step.getColorSecondary(),
                         step.getPrincipalTextColor(), step.getSecondaryTextColor(), step.getActionFailedColor());
             }
@@ -270,7 +297,8 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         StepLayout stepLayout = createLayoutFromStep(step);
         if (stepLayout instanceof SurveyStepLayout) {
             ((SurveyStepLayout) stepLayout).initialize(step, result, colorPrimary, colorSecondary, principalTextColor, secondaryTextColor);
-            ((SurveyStepLayout) stepLayout).isStepEmpty().observe(this, (isEmpty) -> { });
+            ((SurveyStepLayout) stepLayout).isStepEmpty().observe(this, (isEmpty) -> {
+            });
         } else if (stepLayout instanceof ConsentVisualStepLayout) {
             ((ConsentVisualStepLayout) stepLayout).initialize(step, result, colorPrimary, colorSecondary, principalTextColor, secondaryTextColor);
         } else {
@@ -342,11 +370,9 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
                     .negativeColor(colorPrimary)
                     .negativeText(R.string.rsb_cancel)
                     .positiveText(R.string.rsb_task_cancel_positive)
-                    .onPositive(new MaterialDialog.SingleButtonCallback()
-                    {
+                    .onPositive(new MaterialDialog.SingleButtonCallback() {
                         @Override
-                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which)
-                        {
+                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                             finish();
                         }
                     })
@@ -429,11 +455,9 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         AlertDialog alertDialog = new AlertDialog.Builder(this).setTitle(
                 "Are you sure you want to exit?")
                 .setMessage(R.string.lorem_medium)
-                .setPositiveButton("End Task", new DialogInterface.OnClickListener()
-                {
+                .setPositiveButton("End Task", new DialogInterface.OnClickListener() {
                     @Override
-                    public void onClick(DialogInterface dialogInterface, int i)
-                    {
+                    public void onClick(DialogInterface dialogInterface, int i) {
                         finish();
                     }
                 })
@@ -464,11 +488,9 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
     }
 
     private void setActivityTheme(final int primaryColor, final int primaryColorDark) {
-        runOnUiThread(new Runnable()
-        {
+        runOnUiThread(new Runnable() {
             @Override
-            public void run()
-            {
+            public void run() {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     Window window = getWindow();
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/permissions/PermissionListener.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/permissions/PermissionListener.java
@@ -3,5 +3,14 @@ package org.researchstack.backbone.ui.permissions;
 import androidx.annotation.NonNull;
 
 public interface PermissionListener {
+    /**
+     * Callback for when a {@link PermissionMediator} issues the response from a permission
+     * request.
+     * <b>The name is misleading</b>, because the permission result doesn't guarantee in any
+     * capacity that the permission is granted; always check again.
+     *
+     * @param permissionResult the result of the permission request. Cannot be null, but doesn't
+     *                         imply the permission was granted.
+     */
     void onPermissionGranted(@NonNull PermissionResult permissionResult);
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/permissions/PermissionMediator.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/permissions/PermissionMediator.java
@@ -1,5 +1,9 @@
 package org.researchstack.backbone.ui.permissions;
 
+import androidx.annotation.NonNull;
+
 public interface PermissionMediator {
     void requestPermissions(String... permissions);
+
+    boolean checkIfShouldShowRequestPermissionRationale(@NonNull String permission);
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/permissions/PermissionResult.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/permissions/PermissionResult.java
@@ -1,10 +1,11 @@
 package org.researchstack.backbone.ui.permissions;
 
 import android.content.pm.PackageManager;
-import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
 
 public class PermissionResult {
 
@@ -21,6 +22,7 @@ public class PermissionResult {
     }
 
     public boolean isGranted(String permission) {
-        return permissionResults.get(permission) == PackageManager.PERMISSION_GRANTED;
+        final Integer result = permissionResults.get(permission);
+        return result != null && result == PackageManager.PERMISSION_GRANTED;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -296,4 +296,8 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
         this.allStepsAreOptional = allStepsAreOptional;
     }
+
+    public StepBody getStepBody() {
+        return stepBody;
+    }
 }


### PR DESCRIPTION
### Objective
* Request permissions in an Android M+ compatible way across all three types of steps. 

### Description
* Android API "shouldRequestRationale" returns false if you have never requested the permission. The only way to know this, is by keeping track of it, hence why I get the SharedPreferences and store the permission name with a "true" if I requested it (regardless of whether the user accepted it or not).
* After that, it's just a matter of following the flag + the result of the request. 
* File reformatting across the modified files, sorry for the noise.

### How to Test (only truly valid for API 23 / M, since lower apis get the permissions via the manifest).

### *Check out the same branch in AXON, for there are shared changes*

0. **Start with a fresh install (that is, uninstall your current flask version).** 
1. Start and log in to QA/Hybridstudy/Fede Study (fforciniti+qa1@medable.com | qpal1010)
2. **do not grant** permissions during the welcome screens, reach the end and continue without permissions despite the alert dialog. **Do not press the permissions buttons** (or android will know you've asked for the permission once and you'll miss testing part of the logic, which is to ensure this works even if the permission is being asked for the very first time).
3. Once in the Task List, and without permissions, you have to test 3 steps:
* Barcode (for the Barcode scanner which needs Camera permission)
* Image Capture (Camera permission as well).
* Location (for the Location step which needs FINE_LOCATION permission)

Each of these 3 types of steps, have similar, albeit duplicated code and requirements. The first two need Camera, and the last one needs Location. Unfortunately _you're going to want to be in STEP 3 above for each one individually, that means you're going to have to uninstall/reinstall the app a couple of times to ensure you're starting fresh_. 

Enter your task of choice (Barcode for example), and observe:

1. You see the button to grant permissions.
2. Tap the button, and you *should see the permission dialog*. Depending which API version, you can see a regular dialog or an iOS-esque dialog with the three buttons vertically aligned. In any case, **deny the permission**.
3. Tap the permissions button again and observe it now says: don't ask again as an option. 
4. Now you have two choices (and since the logic is the same, you can test one flow with Barcode and one flow with the image capture to cover all bases): You can Grant the permission, and observe that the barcode screen updates to .. well.. the barcode scanner **or**, you can DENY and tell android not to ask you again. 
5. If you denied tap the button again and notice you may be now taken to the Settings screen (old behavior). 
6. If you accepted the permission, go to the other similar task (e.g. to image capture) and observe you indeed have the permission and the camera opens. 

Reset everything and go back to step Zero (0).

Do the same with the Location Permission. Play around with it. Notice the states. Is it working as intended? Does it ask you for permission OR sends you to settings?

**WARNING:** Android 8.x is known to have issues with permissions and uninstalled apps (sometimes you uninstall an app, install it again, and even tho it's a fresh install, asking for a permission will be immediately denied and the user won't see the dialog). The solution to this, is to manually go to settings, GRANT the permission, open the app, close the app, go to settings, remove the permission, launch the app, uninstall the app, and start over. I've only seen this happening on Android 8.1 on my Nexus 5X (old!), but this has happened to me in different apps, not just flask. Keep that in mind. 


