### PR TITLE
PAT-1197: Fixing crash while uploading consent response

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
+++ b/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
@@ -61,6 +61,6 @@ public class LocaleUtils {
 
     public static String getPreferredLocale(Context context) {
         SharedPreferences sharedPrefs = context.getSharedPreferences(LOCALE_PREFERENCES, MODE_PRIVATE);
-        return sharedPrefs.getString(PREFERRED_LOCALE_FIELD, null);
+        return sharedPrefs.getString(PREFERRED_LOCALE_FIELD, "");
     }
 }

--- a/backbone/src/test/java/org/researchstack/backbone/task/TaskTest.java
+++ b/backbone/src/test/java/org/researchstack/backbone/task/TaskTest.java
@@ -38,7 +38,7 @@ public class TaskTest {
         Mockito.when(mockResources.getConfiguration()).thenReturn(mockConfiguration);
         Mockito.when(mockContext.createConfigurationContext(anyObject())).thenReturn(mockContext);
         Mockito.when(mockContext.getSharedPreferences(LocaleUtils.LOCALE_PREFERENCES, Context.MODE_PRIVATE)).thenReturn(mockSp);
-        Mockito.when(mockSp.getString(LocaleUtils.PREFERRED_LOCALE_FIELD, null)).thenReturn("en_US");
+        Mockito.when(mockSp.getString(LocaleUtils.PREFERRED_LOCALE_FIELD, "")).thenReturn("en_US");
         Mockito.when(mockResources.getString(R.string.app_name)).thenReturn("title");
 
         Step mockStepWithTitle = Mockito.mock(Step.class);


### PR DESCRIPTION
- The crash happened when there is not preferred language is set yet, so when we try to retrieve it, it returns null. Fixed it with an empty string instead of null.
- https://jira.devops.medable.com/browse/PAT-1197

Fixes PAT-1197