### PR TITLE
Bug/pat 1211 fixing hidden step

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/task/OrderedTask.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/OrderedTask.java
@@ -127,9 +127,20 @@ public class OrderedTask extends Task implements Serializable {
         String title = super.getTitleForStep(context, step);
         if (TextUtils.isEmpty(title)) {
             int currentIndex = steps.indexOf(step);
+            int currentIndexWithoutHidden = 0;
+            int maxIndexWithoutHidden = 0;
+            for(int i = 0; i < steps.size();i++) {
+                step = steps.get(i);
+                if (!step.isHidden()) {
+                   maxIndexWithoutHidden++;
+                   if (i <= currentIndex) {
+                       currentIndexWithoutHidden++;
+                   }
+                }
+            }
             title = LocaleUtils.getLocalizedString(context, R.string.rsb_format_step_title,
-                    currentIndex + 1,
-                    steps.size());
+                    currentIndexWithoutHidden,
+                    maxIndexWithoutHidden);
         }
         return title;
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -201,6 +201,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         } else {
             if(previousStep.isHidden()) {
                 // The previous step was a hidden one so we go back again
+                currentStep = previousStep;
                 showPreviousStep();
             } else {
                 showStep(previousStep, true);


### PR DESCRIPTION
Fix two issues : 
- The application crash when we use the back button when the previous step was a hiddenStep
- The toolbar title was wrong when there is a hiddenStep. Fix it to avoid to count the hiddenStep.

You can use the following study to perform the test:

* environment: int-dev
* organization: jaimesdesousagomes
* study: Test study
* public user is enough. No need to log in
* task : HiddenStepTask

How to test it : just play with this task and verify the title and the back process.

Closed [PAT-1211](https://jira.devops.medable.com/browse/PAT-1211)