### PR TITLE
PAT-1229: Update Dependencies, CompileSDK, and BuildTool versions.

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 android {
 
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.2'
     afterEvaluate {
         def originalFilePath = "$buildDir/outputs/aar/backbone-release.aar"
         def newFilePath = originalFilePath.replace(".aar", "_v${defaultConfig.versionName}.aar")
@@ -38,7 +38,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
+    
     packagingOptions {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
@@ -53,15 +53,14 @@ android {
     resourcePrefix 'rsb_'
 }
 dependencies {
-    def supportLibVersion = '28.0.0'
 
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'com.google.code.gson:gson:2.4'
+    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'io.reactivex:rxjava:1.1.3'
     implementation 'io.reactivex:rxandroid:1.1.0'
     implementation ('com.jakewharton.rxbinding:rxbinding:0.2.0') {
@@ -105,7 +104,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-v4'
     }
 
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.0'
     testImplementation 'org.mockito:mockito-core:1.10.19'


### PR DESCRIPTION
### Objective
* Keep the dependencies up 2 date.

### Updates

- AppCompat 1.0.2 -> 1.1.0
- Gson 2.4 -> 2.8.5
- Lifecycle 2.0.0 -> 2.1.0

### How to test
1. Checkout `task/PAT-1229_october2019_dependencies_update ` **in both CORTEX and RS**.
2. Smoke test, nothing fancy as you can see in the changes.