### PR TITLE
PAT-1236: Update screenshot blocking  for Huawei devices

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
@@ -67,8 +67,7 @@ public class PinCodeActivity extends AppCompatActivity implements StorageAccessL
     @Override
     protected void onResume() {
         super.onResume();
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-        
+
         requestStorageAccess();
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
@@ -53,12 +53,12 @@ public class PinCodeActivity extends AppCompatActivity implements StorageAccessL
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,WindowManager.LayoutParams.FLAG_SECURE);
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,WindowManager.LayoutParams.FLAG_SECURE);
 
         LogExt.i(getClass(), "logAccessTime()");
         StorageAccess.getInstance().logAccessTime();
@@ -68,7 +68,7 @@ public class PinCodeActivity extends AppCompatActivity implements StorageAccessL
     protected void onResume() {
         super.onResume();
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-
+        
         requestStorageAccess();
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewVideoActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewVideoActivity.java
@@ -29,6 +29,7 @@ public class ViewVideoActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         super.setContentView(R.layout.rsb_activity_video_viewer);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,WindowManager.LayoutParams.FLAG_SECURE);
 
         videoView = (AssetVideoView) findViewById(R.id.videoView);
 
@@ -49,7 +50,6 @@ public class ViewVideoActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,WindowManager.LayoutParams.FLAG_SECURE);
 
         if (videoView.isPlaying()) {
             videoView.pause();

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewVideoActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewVideoActivity.java
@@ -56,9 +56,4 @@ public class ViewVideoActivity extends AppCompatActivity {
         }
     }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-    }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewWebDocumentActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewWebDocumentActivity.java
@@ -168,9 +168,4 @@ public class ViewWebDocumentActivity extends AppCompatActivity {
         });
     }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-    }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewWebDocumentActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewWebDocumentActivity.java
@@ -80,6 +80,8 @@ public class ViewWebDocumentActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,WindowManager.LayoutParams.FLAG_SECURE);
+
         if (getIntent() != null && getIntent().hasExtra(KEY_THEME)) {
             setTheme(getIntent().getIntExtra(KEY_THEME, 0));
         }
@@ -164,12 +166,6 @@ public class ViewWebDocumentActivity extends AppCompatActivity {
                 window.setStatusBarColor(primaryColorDark);
             }
         });
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,WindowManager.LayoutParams.FLAG_SECURE);
     }
 
     @Override


### PR DESCRIPTION
The purpose of this ticket is making screenshot blocking works properly in HUAWEI devices. The current implementation does not work in that brand.

This refactoring will just set the flag on onCreate() and we will no longer need to unset it.