### PR TITLE
Fixed not working consent task & step navigation when pressing "recent tasks" button.

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentViewTaskActivity.java
@@ -32,6 +32,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.researchstack.backbone.ui.step.layout.ConsentSignatureStepLayout.KEY_SIGNATURE;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_TASK;
 
 public class ConsentViewTaskActivity extends ViewTaskActivity implements StepCallbacks {
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -1,5 +1,15 @@
 package org.researchstack.backbone.ui;
 
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_TASK_RESULT;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_ACTION_FAILED_COLOR;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_COLOR_PRIMARY;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_COLOR_PRIMARY_DARK;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_COLOR_SECONDARY;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_PRINCIPAL_TEXT_COLOR;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_SECONDARY_TEXT_COLOR;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_TASK;
+import static org.researchstack.backbone.ui.task.TaskActivity.EXTRA_STEP;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -23,6 +33,10 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.Theme;
 
+import java.lang.reflect.Constructor;
+import java.util.Date;
+import java.util.List;
+
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.result.TaskResult;
@@ -41,10 +55,6 @@ import org.researchstack.backbone.ui.step.layout.SurveyStepLayout;
 import org.researchstack.backbone.ui.views.StepSwitcher;
 import org.researchstack.backbone.utils.ViewUtils;
 
-import java.lang.reflect.Constructor;
-import java.util.Date;
-import java.util.List;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.ActionBar;
@@ -52,16 +62,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 
 public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, PermissionMediator {
-    public static final String EXTRA_TASK = "ViewTaskActivity.ExtraTask";
-    public static final String EXTRA_TASK_RESULT = "ViewTaskActivity.ExtraTaskResult";
-    public static final String EXTRA_STEP = "ViewTaskActivity.ExtraStep";
-    public static final String EXTRA_COLOR_PRIMARY = "ViewTaskActivity.ExtraColorPrimary";
-    public static final String EXTRA_COLOR_PRIMARY_DARK = "ViewTaskActivity.ExtraColorPrimaryDark";
-    public static final String EXTRA_COLOR_SECONDARY = "ViewTaskActivity.ExtraColorSecondary";
-    public static final String EXTRA_PRINCIPAL_TEXT_COLOR = "ViewTaskActivity.ExtraPrincipalTextColor";
-    public static final String EXTRA_SECONDARY_TEXT_COLOR = "ViewTaskActivity.ExtraSecondaryTextColor";
-    public static final String EXTRA_ACTION_FAILED_COLOR = "ViewTaskActivity.ExtraActionFailedColor";
-
     private static final int STEP_PERMISSION_REQUEST = 44;
 
     private StepSwitcher root;

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -30,13 +30,6 @@ import org.researchstack.backbone.ui.permissions.PermissionMediator
 import org.researchstack.backbone.ui.permissions.PermissionResult
 import org.researchstack.backbone.ui.step.layout.StepLayout
 import org.researchstack.backbone.ui.step.layout.SurveyStepLayout
-import org.researchstack.backbone.ui.task.TaskViewModel.Companion.EXTRA_ACTION_FAILED_COLOR
-import org.researchstack.backbone.ui.task.TaskViewModel.Companion.EXTRA_COLOR_PRIMARY
-import org.researchstack.backbone.ui.task.TaskViewModel.Companion.EXTRA_COLOR_PRIMARY_DARK
-import org.researchstack.backbone.ui.task.TaskViewModel.Companion.EXTRA_COLOR_SECONDARY
-import org.researchstack.backbone.ui.task.TaskViewModel.Companion.EXTRA_PRINCIPAL_TEXT_COLOR
-import org.researchstack.backbone.ui.task.TaskViewModel.Companion.EXTRA_SECONDARY_TEXT_COLOR
-import org.researchstack.backbone.ui.task.TaskViewModel.Companion.EXTRA_TASK
 import org.researchstack.backbone.utils.ViewUtils
 
 class TaskActivity : PinCodeActivity(), PermissionMediator {
@@ -100,7 +93,7 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
     override fun onDataReady() {
         super.onDataReady()
 
-        viewModel.nextStep()
+        viewModel.showCurrentStep()
     }
 
     override fun onDataFailed() {
@@ -222,6 +215,15 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
 
     companion object {
         const val EXTRA_TASK_RESULT = "TaskActivity.ExtraTaskResult"
+        const val EXTRA_TASK = "TaskActivity.ExtraTask"
+        const val EXTRA_STEP = "ViewTaskActivity.ExtraStep";
+        const val EXTRA_COLOR_PRIMARY = "TaskActivity.ExtraColorPrimary"
+        const val EXTRA_COLOR_PRIMARY_DARK = "TaskActivity.ExtraColorPrimaryDark"
+        const val EXTRA_COLOR_SECONDARY = "TaskActivity.ExtraColorSecondary"
+        const val EXTRA_PRINCIPAL_TEXT_COLOR = "TaskActivity.ExtraPrincipalTextColor"
+        const val EXTRA_SECONDARY_TEXT_COLOR = "TaskActivity.ExtraSecondaryTextColor"
+        const val EXTRA_ACTION_FAILED_COLOR = "TaskActivity.ExtraActionFailedColor"
+
         private const val STEP_PERMISSION_REQUEST = 44
 
         fun newIntent(context: Context, task: Task): Intent {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -10,15 +10,22 @@ import org.researchstack.backbone.result.TaskResult
 import org.researchstack.backbone.step.Step
 import org.researchstack.backbone.task.Task
 import org.researchstack.backbone.ui.SingleLiveEvent
+import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_ACTION_FAILED_COLOR
+import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_COLOR_PRIMARY
+import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_COLOR_PRIMARY_DARK
+import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_COLOR_SECONDARY
+import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_PRINCIPAL_TEXT_COLOR
+import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_SECONDARY_TEXT_COLOR
+import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_TASK
 import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_TASK_RESULT
-import java.util.*
+import java.util.Date
 
 internal class TaskViewModel(context: Application, intent: Intent) : AndroidViewModel(context) {
 
     var taskResult: TaskResult
     var currentStep: Step? = null
 
-    val task: Task
+    val task: Task = intent.getSerializableExtra(EXTRA_TASK) as Task
     val colorPrimary = intent.getIntExtra(EXTRA_COLOR_PRIMARY, R.color.rsb_colorPrimary)
     val colorPrimaryDark = intent.getIntExtra(EXTRA_COLOR_PRIMARY_DARK, R.color.rsb_colorPrimaryDark)
     val colorSecondary = intent.getIntExtra(EXTRA_COLOR_SECONDARY, R.color.rsb_colorAccent)
@@ -30,11 +37,16 @@ internal class TaskViewModel(context: Application, intent: Intent) : AndroidView
     val currentStepEvent = MutableLiveData<StepNavigationEvent>()
 
     init {
-        task = intent.getSerializableExtra(EXTRA_TASK) as Task
         taskResult = intent.extras?.get(EXTRA_TASK_RESULT) as TaskResult?
                 ?: TaskResult(task.identifier).apply { startDate = Date() }
 
         task.validateParameters()
+    }
+
+    fun showCurrentStep() {
+        if (currentStep == null) {
+            nextStep()
+        }
     }
 
     fun nextStep() {
@@ -85,15 +97,5 @@ internal class TaskViewModel(context: Application, intent: Intent) : AndroidView
 
         result.result = step.hiddenDefaultValue
         taskResult.setStepResultForStep(step, result)
-    }
-
-    companion object {
-        const val EXTRA_TASK = "TaskActivity.ExtraTask"
-        const val EXTRA_COLOR_PRIMARY = "TaskActivity.ExtraColorPrimary"
-        const val EXTRA_COLOR_PRIMARY_DARK = "TaskActivity.ExtraColorPrimaryDark"
-        const val EXTRA_COLOR_SECONDARY = "TaskActivity.ExtraColorSecondary"
-        const val EXTRA_PRINCIPAL_TEXT_COLOR = "TaskActivity.ExtraPrincipalTextColor"
-        const val EXTRA_SECONDARY_TEXT_COLOR = "TaskActivity.ExtraSecondaryTextColor"
-        const val EXTRA_ACTION_FAILED_COLOR = "TaskActivity.ExtraActionFailedColor"
     }
 }


### PR DESCRIPTION
- consent task was not working, there was a NPE when trying to complete a consent task
- Also fixed navigation issue when pressing device "recent apps" button. When pressing this button, and then selecting the App from the recent's Apps list, the activity moved immediately to the next step

how to test this:
Fix 1:
- Try to complete a consent task (you should complete it successfully, without any crash)

Fix 2
- Open a task with more than 1 step
- With the task opened, press "recent Apps" button
- Select Flask from the recent apps
- When selecting Flask from the recent apps, selected step should be the same, the app should not navigate to the next step

NOTE: 
1- on PAT, checkout bug/review-step-consent-task-fix
2- axon, checkout task/PAT-1294-review-step
3- RS, checkout bug/review-step-consent-task-fix