### PR TITLE
PAT-1403: Fixed granting permission for location step to refresh the layout

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -219,8 +219,8 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         } else if (requestCode == STEP_PERMISSION_LISTENER_REQUEST) {
             PermissionResult result = new PermissionResult(permissions, grantResults);
             stepPermissionListener.onPermissionGranted(result);
+            stepPermissionListener = null;
         }
-        stepPermissionListener = null;
     }
 
     /**

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -63,6 +63,7 @@ import androidx.appcompat.widget.Toolbar;
 
 public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, PermissionMediator {
     private static final int STEP_PERMISSION_REQUEST = 44;
+    private static final int STEP_PERMISSION_LISTENER_REQUEST = 45;
 
     private StepSwitcher root;
 
@@ -80,6 +81,7 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
     private ActionBar actionBar;
 
     private int stepCount = 0;
+    private PermissionListener stepPermissionListener;
 
     public static Intent newIntent(Context context, Task task) {
         Intent intent = new Intent(context, ViewTaskActivity.class);
@@ -148,6 +150,13 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
         task.onViewChange(Task.ViewChangeType.ActivityCreate, this, currentStep);
     }
 
+    @Override
+    public void requestPermissions(PermissionListener permissionListener, String... permissions) {
+        stepPermissionListener = permissionListener;
+        requestPermissions(permissions, STEP_PERMISSION_LISTENER_REQUEST);
+        requestPermissions(permissions);
+    }
+
     @RequiresApi(Build.VERSION_CODES.M)
     @Override
     public void requestPermissions(String... permissions) {
@@ -207,7 +216,11 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
             if (stepBody instanceof PermissionListener) {
                 ((PermissionListener) stepBody).onPermissionGranted(result);
             }
+        } else if (requestCode == STEP_PERMISSION_LISTENER_REQUEST) {
+            PermissionResult result = new PermissionResult(permissions, grantResults);
+            stepPermissionListener.onPermissionGranted(result);
         }
+        stepPermissionListener = null;
     }
 
     /**

--- a/backbone/src/main/java/org/researchstack/backbone/ui/permissions/PermissionMediator.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/permissions/PermissionMediator.java
@@ -3,6 +3,8 @@ package org.researchstack.backbone.ui.permissions;
 import androidx.annotation.NonNull;
 
 public interface PermissionMediator {
+    void requestPermissions(PermissionListener permissionListener, String... permissions);
+
     void requestPermissions(String... permissions);
 
     boolean checkIfShouldShowRequestPermissionRationale(@NonNull String permission);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -38,6 +38,7 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
     private val viewModel: TaskViewModel by viewModel { parametersOf(intent) }
     private val navController by lazy { Navigation.findNavController(this, R.id.nav_host_fragment) }
     private var currentStepLayout: StepLayout? = null
+    private var stepPermissionListener: PermissionListener? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -104,6 +105,12 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
         finish()
     }
 
+    override fun requestPermissions(permissionListener: PermissionListener, vararg permissions:
+    String?) {
+        stepPermissionListener = permissionListener
+        requestPermissions(permissions, STEP_PERMISSION_LISTENER_REQUEST)
+    }
+
     @RequiresApi(Build.VERSION_CODES.M)
     override fun requestPermissions(vararg permissions: String?) {
         requestPermissions(permissions, STEP_PERMISSION_REQUEST)
@@ -140,7 +147,11 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
             if (stepBody is PermissionListener) {
                 (stepBody as PermissionListener).onPermissionGranted(result)
             }
+        } else if (requestCode == STEP_PERMISSION_LISTENER_REQUEST) {
+            val result = PermissionResult(permissions, grantResults)
+            stepPermissionListener?.onPermissionGranted(result)
         }
+        stepPermissionListener = null
     }
 
     override fun checkIfShouldShowRequestPermissionRationale(permission: String): Boolean {
@@ -234,6 +245,7 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
         const val EXTRA_ACTION_FAILED_COLOR = "TaskActivity.ExtraActionFailedColor"
 
         private const val STEP_PERMISSION_REQUEST = 44
+        private const val STEP_PERMISSION_LISTENER_REQUEST = 45
 
         fun newIntent(context: Context, task: Task): Intent {
             return Intent(context, TaskActivity::class.java).apply {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -150,8 +150,8 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
         } else if (requestCode == STEP_PERMISSION_LISTENER_REQUEST) {
             val result = PermissionResult(permissions, grantResults)
             stepPermissionListener?.onPermissionGranted(result)
+            stepPermissionListener = null
         }
-        stepPermissionListener = null
     }
 
     override fun checkIfShouldShowRequestPermissionRationale(permission: String): Boolean {


### PR DESCRIPTION
### Objective
- Fixes PAT-1403 Making sure that when we grant permission for Location Step, the layout gets refreshed.
### How/Why
- How: I added a new method in `PermissionMediator` to take `PermissionListener` that is notified when the permission result is reached.
- Why: Because the Location Step isn't a layout. and therefore is going to be visited when we call the normal `PermissionMediator.requestPermission()` and expect the result in `TaskActivity.onRequestPermissionsResult()`
### How To Test
- Please follow instructions for PAT-1403 (link below)
##### Branches
- PAT: task/PAT-1294-review-step
- Axon: bug/PAT-1402_PAT-1403_fix_overlap_step_views
- RS: bug/PAT-1402_PAT-1403_fix_overlap_step_views
- Cortex: development
### Links
- https://jira.devops.medable.com/browse/PAT-1403

Closes PAT-1402, PAT-1403