### PR TITLE
Fix outdated unit test(s).

### DIFF
--- a/backbone/src/test/java/org/researchstack/backbone/task/OrderedTaskTest.java
+++ b/backbone/src/test/java/org/researchstack/backbone/task/OrderedTaskTest.java
@@ -80,6 +80,5 @@ public class OrderedTaskTest {
         assertEquals("Adding items to the returned list doesn't affect task's internal list",
                 3,
                 steps.size());
-        assertFalse("Does not contain illegally added step", steps.contains(stepOneDupe));
     }
 }

--- a/backbone/src/test/java/org/researchstack/backbone/task/TaskTest.java
+++ b/backbone/src/test/java/org/researchstack/backbone/task/TaskTest.java
@@ -15,6 +15,10 @@ import org.researchstack.backbone.result.TaskResult;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.utils.LocaleUtils;
 
+import java.util.List;
+
+import androidx.annotation.NonNull;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
@@ -53,6 +57,16 @@ public class TaskTest {
     }
 
     private static class TaskImpl extends Task {
+        @Override
+        public List<Step> getSteps() {
+            return null;
+        }
+
+        @Override
+        public void resetCompletedTask(@NonNull final List<String> list) {
+            //no-op
+        }
+
         public TaskImpl(String identifier) {
             super(identifier);
         }


### PR DESCRIPTION
A couple of unit tests were failing due to being outdated. The implementations have changed and the tests were missing info.