### PR TITLE
PAT-1433: hidden steps visible when back is pressed

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -146,7 +146,12 @@ internal class TaskViewModel(context: Application, intent: Intent) : AndroidView
 
     }
 
-    fun previousStep() {
+    /**
+     * Goes to previous step, and in case of editing, it pops from the stack where previous steps were stored
+     * @param popUpToStep Used to keep track of the last visible step before encountering any hidden steps, as we might
+     * have several consecutive hidden steps
+     */
+    fun previousStep(popUpToStep : Step? = currentStep) {
         Log.d(TAG, "1. CURRENT STEP: $currentStep")
         if (editing) {
             currentStep = stack.pop()
@@ -161,13 +166,15 @@ internal class TaskViewModel(context: Application, intent: Intent) : AndroidView
             } else {
 
                 if (previousStep.isHidden) {
+                    val lastVisibleStep = if (currentStep?.isHidden!!) popUpToStep else currentStep
+                    currentStep = previousStep
                     // The previous step was a hidden one so we go previousStep again
-                    previousStep()
+                    previousStep(lastVisibleStep)
                 } else {
-                    currentStepEvent.value = StepNavigationEvent(popUpToStep = currentStep, step = previousStep, isMovingForward = false)
+                    currentStep = previousStep
+                    currentStepEvent.value = StepNavigationEvent(popUpToStep = popUpToStep, step = previousStep, isMovingForward = false)
                 }
 
-                currentStep = previousStep
 
             }
         }


### PR DESCRIPTION
### Objective
- Fix PAT-1433 -> Hidden steps are visible when we go back from next step.

### How/Why
- How: resolved this by keeping track of the last visible step (ReviewStep in our case), and finding the first visible step before that one.
- Why: This is to avoid having issues when we have more than one consecutive hidden steps.

### How To Test
- Please follow instructions for 1433 (link below)

##### Branches
- PAT: task/PAT-1294-review-step
- Axon: bug/PAT-1433-hidden_steps_visible_when_back_pressed
- RS: bug/PAT-1433-hidden_steps_visible_when_back_pressed
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1433

Closes PAT-1433