### PR TITLE
PAT-1434: Make ReviewStep headers dynamic and scrollable.

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -1,6 +1,5 @@
 package org.researchstack.backbone.ui.step.fragments
 
-import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.annotation.LayoutRes

--- a/backbone/src/main/res/layout/rsb_review_step_header_layout.xml
+++ b/backbone/src/main/res/layout/rsb_review_step_header_layout.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/reviewStepHeaderTitle"
+        style="@style/rsb_review_step_title_style"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        app:layout_constraintVertical_chainStyle="packed"
+        android:paddingBottom="20dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/reviewStepHeaderSubTitle"
+        tools:text="Review" />
+
+    <TextView
+        android:id="@+id/reviewStepHeaderSubTitle"
+        style="@style/rsb_review_step_sub_step_question_style"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textStyle="normal"
+        android:paddingBottom="10dp"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/reviewStepHeaderTitle"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="Please review your response - tap to edit." />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/backbone/src/main/res/values/styles.xml
+++ b/backbone/src/main/res/values/styles.xml
@@ -142,6 +142,12 @@
         <item name="android:scaleType">fitCenter</item>
     </style>
 
+    <style name="rsb_review_step_title_style">
+        <item name="android:textColor">@color/rsb_black</item>
+        <item name="android:textSize">32sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="rsb_review_step_sub_step_title_style">
         <item name="android:textColor">@color/rsb_black</item>
         <item name="android:textSize">18sp</item>


### PR DESCRIPTION
### Objective
* Produce scrollable headers in the ReviewStep list. 
* Respect ReviewStep title/description in said header. 

### Description
* In order to avoid using a NestedScrollView (Which disrupts the RecyclerView internal functioning), I've added a new step type: `ReviewStepInternalHeader`, that maps to `StepType.ReviewStepHeader`.
* The Dummy type is handled by the Adapter, and not Axon or Backbone themselves, that is why this object is not on Axon. It's an artifact that pertains the ReviewStep adapter alone.
* The RecyclerView layout has been stripped of the hardcoded title/description.
* The meat of this Pull Request is only visible on Axon. 

### How to Test: 
1. Check out the same branch (`task/PAT-1434_reviewstep_headers`) in both **Axon** and **ResearchStack**.
2. Reach the end of any task with a ReviewStep and observe the title/description can scroll, as well as they respect the values in the Web portal. 

**This Pull Request doesn't work alone, it needs changes in Axon**