### PR TITLE
Fix Error when going back will save steps from different branchs

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/result/TaskResult.java
+++ b/backbone/src/main/java/org/researchstack/backbone/result/TaskResult.java
@@ -106,6 +106,16 @@ public class TaskResult extends Result implements Cloneable {
         stepsAndResults.put(step, stepResult);
     }
 
+    /**
+     * Remove the Step's result associated with the entire step
+     *
+     * @param step       the Step
+     */
+    public void removeStepResultForStep(@NonNull Step step) {
+        results.remove(step.getIdentifier());
+        stepsAndResults.remove(step);
+    }
+
     @Override
     public Object clone() throws CloneNotSupportedException {
         TaskResult cloned = (TaskResult) super.clone();

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -59,8 +59,8 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
                     stepView.setCancelEditMode(it)
                 })
 
-                viewModel.stepInBackMode.observe(this, Observer {
-                    stepView.setRemoveFomBackStack(it)
+                viewModel.stepBackNavigationState.observe(this, Observer {
+                    stepView.setRemoveFromBackStack(it)
                 })
             }
             is StepLayout -> {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -58,6 +58,10 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
                 viewModel.updateCancelEditInLayout.observe(this, Observer {
                     stepView.setCancelEditMode(it)
                 })
+
+                viewModel.stepInBackMode.observe(this, Observer {
+                    stepView.setRemoveFomBackStack(it)
+                })
             }
             is StepLayout -> {
                 stepView.initialize(currentStep, stepResult)

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -260,8 +260,8 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
     @Override
     public Parcelable onSaveInstanceState() {
-        if (!isCancelEdit)
-            callbacks.onSaveStep(StepCallbacks.ACTION_NONE, getStep(), stepBody.getStepResult(isSkipped));
+//        if (!isCancelEdit)
+//            callbacks.onSaveStep(StepCallbacks.ACTION_NONE, getStep(), stepBody.getStepResult(isSkipped));
         return super.onSaveInstanceState();
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -62,7 +62,12 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
     private boolean isSkipped = false;
     private boolean isCancelEdit = false;
+    private boolean removeFomBackStack = false;
 
+
+    public void setRemoveFomBackStack(boolean backMode) {
+        removeFomBackStack = backMode;
+    }
 
     private MediatorLiveData<Boolean> mediator = new MediatorLiveData<>();
     private boolean allStepsAreOptional;
@@ -260,8 +265,8 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
     @Override
     public Parcelable onSaveInstanceState() {
-//        if (!isCancelEdit)
-//            callbacks.onSaveStep(StepCallbacks.ACTION_NONE, getStep(), stepBody.getStepResult(isSkipped));
+        if (!isCancelEdit && !removeFomBackStack)
+            callbacks.onSaveStep(StepCallbacks.ACTION_NONE, getStep(), stepBody.getStepResult(isSkipped));
         return super.onSaveInstanceState();
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -62,11 +62,11 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
     private boolean isSkipped = false;
     private boolean isCancelEdit = false;
-    private boolean removeFomBackStack = false;
+    private boolean removeFromBackStack = false;
 
 
-    public void setRemoveFomBackStack(boolean backMode) {
-        removeFomBackStack = backMode;
+    public void setRemoveFromBackStack(boolean shouldRemove) {
+        removeFromBackStack = shouldRemove;
     }
 
     private MediatorLiveData<Boolean> mediator = new MediatorLiveData<>();
@@ -265,7 +265,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
     @Override
     public Parcelable onSaveInstanceState() {
-        if (!isCancelEdit && !removeFomBackStack)
+        if (!isCancelEdit && !removeFromBackStack)
             callbacks.onSaveStep(StepCallbacks.ACTION_NONE, getStep(), stepBody.getStepResult(isSkipped));
         return super.onSaveInstanceState();
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -51,7 +51,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     val moveReviewStep = MutableLiveData<StepNavigationEvent>()
     val showEditDialog = MutableLiveData<Boolean>()
     val updateCancelEditInLayout = MutableLiveData<Boolean>()
-    val stepInBackMode = MutableLiveData<Boolean>()
+    val stepBackNavigationState = MutableLiveData<Boolean>()
     val hideMenuItemCancel = MutableLiveData<Boolean>()
 
 
@@ -176,7 +176,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
                     previousStep(lastVisibleStep)
                 } else {
                     taskResult.removeStepResultForStep(currentStep!!)
-                    stepInBackMode.postValue(true)
+                    stepBackNavigationState.postValue(true)
                     currentStep = previousStep
                     currentStepEvent.value = StepNavigationEvent(popUpToStep = popUpToStep, step = previousStep, isMovingForward = false)
                 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -165,6 +165,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
 
         } else {
             val previousStep = task.getStepBeforeStep(currentStep, taskResult)
+            taskResult.removeStepResultForStep(currentStep!!)
             if (previousStep == null) {
                 close()
             } else {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -166,6 +166,8 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
 
         } else {
             val previousStep = task.getStepBeforeStep(currentStep, taskResult)
+            taskResult.removeStepResultForStep(currentStep!!)
+            stepBackNavigationState.postValue(true)
             if (previousStep == null) {
                 close()
             } else {
@@ -175,8 +177,6 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
                     // The previous step was a hidden one so we go previousStep again
                     previousStep(lastVisibleStep)
                 } else {
-                    taskResult.removeStepResultForStep(currentStep!!)
-                    stepBackNavigationState.postValue(true)
                     currentStep = previousStep
                     currentStepEvent.value = StepNavigationEvent(popUpToStep = popUpToStep, step = previousStep, isMovingForward = false)
                 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -51,6 +51,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     val moveReviewStep = MutableLiveData<StepNavigationEvent>()
     val showEditDialog = MutableLiveData<Boolean>()
     val updateCancelEditInLayout = MutableLiveData<Boolean>()
+    val stepInBackMode = MutableLiveData<Boolean>()
     val hideMenuItemCancel = MutableLiveData<Boolean>()
 
 
@@ -165,17 +166,17 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
 
         } else {
             val previousStep = task.getStepBeforeStep(currentStep, taskResult)
-            taskResult.removeStepResultForStep(currentStep!!)
             if (previousStep == null) {
                 close()
             } else {
-
                 if (previousStep.isHidden) {
                     val lastVisibleStep = if (currentStep?.isHidden!!) popUpToStep else currentStep
                     currentStep = previousStep
                     // The previous step was a hidden one so we go previousStep again
                     previousStep(lastVisibleStep)
                 } else {
+                    taskResult.removeStepResultForStep(currentStep!!)
+                    stepInBackMode.postValue(true)
                     currentStep = previousStep
                     currentStepEvent.value = StepNavigationEvent(popUpToStep = popUpToStep, step = previousStep, isMovingForward = false)
                 }
@@ -270,7 +271,6 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     fun cancelEditDismiss() {
         stack.push(currentStep)
     }
-
 
     fun removeUpdatedLayout() {
         updateCancelEditInLayout.postValue(true)


### PR DESCRIPTION
### Objective
Fix when user go back in the middle of branch XX and change his/her answers to branch YY, `taskResult` will hold the answers of the discarded branch 

### How to Test
Fix when user went back back back back back from branch Y .... all the way back to the branch decision and changed the response to now go to branch X. He then hit next/skip etc to complete branch X and finally the review step had all the branch Y+branch X steps...
