### PR TITLE
PAT-1444: Fixed Step titles when editing steps

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -81,7 +81,6 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
             navController.navigate(it.destinationId)
             supportActionBar?.title = ""
         }
-//        NavigationUI.setupActionBarWithNavController(this, navController)
 
         navController.addOnDestinationChangedListener(object : NavController.OnDestinationChangedListener {
             override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -22,12 +22,12 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigation
-import androidx.navigation.ui.NavigationUI
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.Theme
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.researchstack.backbone.R
+import org.researchstack.backbone.step.Step
 import org.researchstack.backbone.task.Task
 import org.researchstack.backbone.ui.PinCodeActivity
 import org.researchstack.backbone.ui.permissions.PermissionListener
@@ -57,6 +57,7 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
         observe(viewModel.currentStepEvent) { showStep(it) }
         observe(viewModel.taskCompleted) { close(it) }
         observe(viewModel.moveReviewStep) {
+            showStepTitle(it.step)
             navController.navigate(it.step.destinationId, null,
                     NavOptions.Builder().setPopUpTo(
                             viewModel.firstStep.destinationId,
@@ -78,8 +79,9 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
 
         observe(viewModel.editStep) {
             navController.navigate(it.destinationId)
+            supportActionBar?.title = ""
         }
-        NavigationUI.setupActionBarWithNavController(this, navController)
+//        NavigationUI.setupActionBarWithNavController(this, navController)
 
         navController.addOnDestinationChangedListener(object : NavController.OnDestinationChangedListener {
             override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
@@ -223,8 +225,14 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
         if (navigationEvent.popUpToStep == null) {
             navController.navigate(navigationEvent.step.destinationId)
         }
-        supportActionBar?.title = viewModel.task.getTitleForStep(this, navigationEvent.step)
+        showStepTitle(navigationEvent.step)
         setActivityTheme(viewModel.colorPrimary, viewModel.colorPrimaryDark)
+    }
+
+    private fun showStepTitle(step: Step) {
+        supportActionBar?.title =
+                if (viewModel.editing) ""
+                else viewModel.task.getTitleForStep(this, step)
     }
 
     private fun hideKeyboard() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -52,7 +52,7 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
 
         setSupportActionBar(findViewById(R.id.toolbar))
 
-        supportActionBar?.setDisplayHomeAsUpEnabled(false)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         observe(viewModel.currentStepEvent) { showStep(it) }
         observe(viewModel.taskCompleted) { close(it) }


### PR DESCRIPTION
### Objective
- PAT-1444 Fixed Step titles when we edit steps that are part of ReviewStep.

### How
- By un-assigning the actionBar from navigation component, and clearing the actionBar title in case of editing, and showing it back when we go to ReviewStep

### How To Test
- Credentials:
  - Environment: int-dev
  - Org: abdallahandela
  - Study: Banadol
- Steps:
  1. Open the app and use the credentials above
  2. Join Study
  3. Take task `ReviewStep Boolean`
  4. Reach to ReviewStep
  5. Edit any of the steps

- Expected: the action bar must be empty, showing no title

##### Branches
- PAT: task/PAT-1294-review-step
- Axon: task/PAT-1294-review-step
- RS: bug/PAT-1444_step_titles_incorrect_when_editing
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1444

Closes PAT-1444