### PR TITLE
Task/pat 1461 add save dialog when user edit

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
+++ b/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
@@ -8,8 +8,11 @@ import org.researchstack.backbone.step.Step;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -166,5 +169,18 @@ public class StepResult<T> extends Result implements Cloneable {
         // this will be updated when the result is set
         cloned.setEndDate((Date) getEndDate().clone());
         return cloned;
+    }
+
+    public Boolean allValuesAreNull() {
+        List<Boolean> tempBoolean = new ArrayList<>();
+        for (Map.Entry<String, T> e : results.entrySet()) {
+            if (e.getValue() instanceof StepResult) {
+                tempBoolean.add(((StepResult) e.getValue()).getResult() == null);
+            } else {
+                tempBoolean.add(e.getValue()== null);
+            }
+        }
+
+        return Collections.frequency(tempBoolean, true) == tempBoolean.size();
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
+++ b/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
@@ -177,7 +177,7 @@ public class StepResult<T> extends Result implements Cloneable {
             if (e.getValue() instanceof StepResult) {
                 tempBoolean.add(((StepResult) e.getValue()).getResult() == null);
             } else {
-                tempBoolean.add(e.getValue()== null);
+                tempBoolean.add(e.getValue() == null);
             }
         }
 

--- a/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
+++ b/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
@@ -172,15 +172,16 @@ public class StepResult<T> extends Result implements Cloneable {
     }
 
     public Boolean allValuesAreNull() {
-        List<Boolean> tempBoolean = new ArrayList<>();
+        int count = 0;
         for (Map.Entry<String, T> e : results.entrySet()) {
-            if (e.getValue() instanceof StepResult) {
-                tempBoolean.add(((StepResult) e.getValue()).getResult() == null);
-            } else {
-                tempBoolean.add(e.getValue() == null);
+            final T value = e.getValue();
+            final boolean isNull = value instanceof StepResult ?
+                    ((StepResult) value).getResult() == null
+                    : value == null;
+            if (isNull) {
+                count++;
             }
         }
-
-        return Collections.frequency(tempBoolean, true) == tempBoolean.size();
+        return results.size() == count;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -500,7 +500,12 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks, 
 
     @Override
     public void onEditCancelStep() {
-    // only when user on edit mode inside reqgular steps
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
+    @Override
+    public void onSkipStep(Step step, StepResult originalStepResult, StepResult modifiedStepResult) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
     }
 
     public void setActionBarTitle(String title) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/callbacks/StepCallbacks.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/callbacks/StepCallbacks.java
@@ -8,6 +8,7 @@ public interface StepCallbacks {
     int ACTION_NONE = 0;
     int ACTION_NEXT = 1;
     int ACTION_END = 2;
+    int ACTION_SAVE = 3;
 
     void onSaveStep(int action, Step step, StepResult result);
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/callbacks/StepCallbacks.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/callbacks/StepCallbacks.java
@@ -19,4 +19,6 @@ public interface StepCallbacks {
 
     void onEditCancelStep();
 
+    void onSkipStep(Step step, StepResult originalStepResult, StepResult modifiedStepResult);
+
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -78,6 +78,9 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
             StepCallbacks.ACTION_NEXT -> viewModel.nextStep()
             StepCallbacks.ACTION_PREV -> viewModel.previousStep()
             StepCallbacks.ACTION_END -> viewModel.taskCompleted.value = true
+            StepCallbacks.ACTION_SAVE -> {
+                viewModel.checkForSaveDialog(result)
+            }
             StepCallbacks.ACTION_NONE -> {
                 // Used when onSaveInstanceState is called of a view. No action is taken.
             }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -18,6 +18,9 @@ import org.researchstack.backbone.ui.task.TaskViewModel
 
 internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment(contentLayoutId), StepCallbacks {
 
+    override fun onSkipStep(step: Step?, originalStepResult: StepResult<*>?, modifiedStepResult: StepResult<*>?) {
+        viewModel.checkForSkipDialog(originalStepResult)
+    }
 
     override fun onEditCancelStep() {
         viewModel.showCancelEditAlert()

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -228,6 +228,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         });
 
         submitBar.setEditSaveAction(view -> {
+            isSkipped = false;
             callbacks.onSaveStep(ACTION_SAVE, getStep(),
                     stepBody.getStepResult(isSkipped));
         });
@@ -298,9 +299,19 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         if (callbacks != null) {
             // empty step result when skipped
             isSkipped = true;
-            callbacks.onSaveStep(isEditViewVisible ? ACTION_SAVE : StepCallbacks.ACTION_NEXT,
-                    getStep(),
-                    stepBody.getStepResult(isSkipped));
+            if (isEditViewVisible) {
+                try {
+                    callbacks.onSkipStep(getStep(),
+                            (StepResult<?>) stepBody.getStepResult(false).clone(),
+                            stepBody.getStepResult(isSkipped));
+                } catch (CloneNotSupportedException e) {
+                    e.printStackTrace();
+                }
+            }else {
+                callbacks.onSaveStep( StepCallbacks.ACTION_NEXT,
+                        getStep(),
+                        stepBody.getStepResult(isSkipped));
+            }
         }
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -223,6 +223,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         }
 
         submitBar.setEditCancelAction(view -> {
+            isSkipped = false;
             stepBody.getStepResult(isSkipped);
             callbacks.onEditCancelStep();
         });

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -164,10 +164,12 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
             submitBar.getPositiveActionView().setVisibility(GONE);
             submitBar.getEditCancelViewActionView().setVisibility(VISIBLE);
             submitBar.getEditSaveViewActionView().setVisibility(VISIBLE);
+            submitBar.getEditSpaceView().setVisibility(VISIBLE);
         } else {
             submitBar.getPositiveActionView().setVisibility(VISIBLE);
             submitBar.getEditCancelViewActionView().setVisibility(GONE);
             submitBar.getEditSaveViewActionView().setVisibility(GONE);
+            submitBar.getEditSpaceView().setVisibility(GONE);
         }
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -62,6 +62,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
     private boolean isSkipped = false;
     private boolean isCancelEdit = false;
+    private boolean isEditViewVisible = false;
     private boolean removeFromBackStack = false;
 
 
@@ -158,6 +159,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
 
     public void isEditView(boolean isEditView) {
+        isEditViewVisible = isEditView;
         if (isEditView) {
             submitBar.getPositiveActionView().setVisibility(GONE);
             submitBar.getEditCancelViewActionView().setVisibility(VISIBLE);
@@ -293,7 +295,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         if (callbacks != null) {
             // empty step result when skipped
             isSkipped = true;
-            callbacks.onSaveStep(StepCallbacks.ACTION_NEXT,
+            callbacks.onSaveStep(isEditViewVisible ? ACTION_SAVE : StepCallbacks.ACTION_NEXT,
                     getStep(),
                     stepBody.getStepResult(isSkipped));
         }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -32,7 +32,7 @@ import org.researchstack.backbone.utils.TextUtils;
 
 import java.lang.reflect.Constructor;
 
-import static org.researchstack.backbone.ui.callbacks.StepCallbacks.ACTION_NEXT;
+import static org.researchstack.backbone.ui.callbacks.StepCallbacks.ACTION_SAVE;
 
 public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout {
     public static final String TAG = SurveyStepLayout.class.getSimpleName();
@@ -218,7 +218,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         });
 
         submitBar.setEditSaveAction(view -> {
-            callbacks.onSaveStep(ACTION_NEXT, getStep(),
+            callbacks.onSaveStep(ACTION_SAVE, getStep(),
                     stepBody.getStepResult(isSkipped));
         });
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -115,10 +115,10 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
         observe(viewModel.showSkipEditDialog) {
             if (it.first) {
                 showAlertDialog(
-                        R.string.rsb_edit_step_alert_step_save_title,
-                        R.string.rsb_edit_step_alert_step_save_content,
-                        R.string.rsb_edit_step_alert_step_save_discard,
-                        R.string.rsb_edit_step_alert_step_save_positive,
+                        R.string.rsb_edit_step_alert_step_skip_title,
+                        R.string.rsb_edit_step_alert_step_skip_content,
+                        R.string.rsb_edit_step_alert_step_skip_discard,
+                        R.string.rsb_edit_step_alert_step_skip_positive,
                         {dialog ->
                             dialog.dismiss()
                             viewModel.revertToOriginalStepResult(it.second)

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -65,12 +65,12 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
 
         }
 
-        observe(viewModel.showEditDialog) {
+        observe(viewModel.showCancelEditDialog) {
             showAlertDialog(
-                    R.string.rsb_task_cancel_title,
                     R.string.rsb_edit_step_alert_cancel_title,
+                    R.string.rsb_edit_step_alert_cancel_content,
                     R.string.rsb_edit_step_alert_cancel_discard,
-                    R.string.rsb_edit_step_alert_cancel_save,
+                    R.string.rsb_edit_step_alert_cancel_positive,
                     {
                         it.dismiss()
                         viewModel.cancelEditDismiss()
@@ -92,6 +92,18 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
                 it.isVisible = !inEditMode
             }
         }
+
+        observe(viewModel.showSaveEditDialog) {
+            showAlertDialog(
+                    R.string.rsb_edit_step_alert_step_save_title,
+                    R.string.rsb_edit_step_alert_step_save_content,
+                    R.string.rsb_edit_step_alert_step_save_discard,
+                    R.string.rsb_edit_step_alert_step_save_positive,
+                    {
+                        it.dismiss()
+                        viewModel.saveEditDialogDismiss()
+                    }, { viewModel.nextStep() }) }
+
     }
 
     override fun onPause() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -68,8 +68,8 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
 
         observe(viewModel.showCancelEditDialog) {
             if (it) {
-                showAlertDialog(R.string.rsb_task_cancel_title,
-                        R.string.rsb_edit_step_alert_cancel_title,
+                showAlertDialog(R.string.rsb_edit_step_alert_cancel_title,
+                        R.string.rsb_edit_step_alert_cancel_content,
                         R.string.rsb_edit_step_alert_cancel_discard,
                         R.string.rsb_edit_step_alert_cancel_positive,
                         {
@@ -108,7 +108,24 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
                     {
                         it.dismiss()
                         viewModel.saveEditDialogDismiss()
-                    }, { viewModel.nextStep() }) }
+                    }, { viewModel.nextStep() })
+        }
+
+
+        observe(viewModel.showSkipEditDialog) {
+            if (it.first) {
+                showAlertDialog(
+                        R.string.rsb_edit_step_alert_step_save_title,
+                        R.string.rsb_edit_step_alert_step_save_content,
+                        R.string.rsb_edit_step_alert_step_save_discard,
+                        R.string.rsb_edit_step_alert_step_save_positive,
+                        {dialog ->
+                            dialog.dismiss()
+                            viewModel.revertToOriginalStepResult(it.second)
+                        }, { viewModel.nextStep() })
+            }
+        }
+
 
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -316,7 +316,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     private fun checkIfNewAnswerIsSkipWhilePreviousIsNot(): Boolean {
         val originalStepResult = clonedTaskResultInCaseOfCancel?.getStepResult(currentStep?.identifier)
         val modifiedStepResult = currentTaskResult.getStepResult(currentStep?.identifier)
-        return originalStepResult?.result != null && modifiedStepResult.result == null
+        return originalStepResult?.allValuesAreNull()!!.not() && modifiedStepResult.allValuesAreNull()
     }
 
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -280,12 +280,18 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     }
 
     fun checkForSaveDialog(stepResult: StepResult<*>?) {
-        if ((!isSavedDialogAppeared && !checkIfAnswersAreTheSame(stepResult) && checkIfCurrentStepIsBranchDecisionStep()) ||
-                (currentStep!!.isOptional && checkIfTheNewAnswerIsSkipWhileThePreviousIsNot(stepResult))) {
-            isSavedDialogAppeared = true
-            showSaveEditDialog.postValue(true)
-        } else {
-            nextStep()
+        when {
+            isSavedDialogAppeared.not() && checkIfAnswersAreTheSame(stepResult).not() && checkIfCurrentStepIsBranchDecisionStep() -> {
+                isSavedDialogAppeared = true
+                showSaveEditDialog.postValue(true)
+            }
+            currentStep!!.isOptional && checkIfNewAnswerIsSkipWhilePreviousIsNot(stepResult) -> {
+                isSavedDialogAppeared = true
+                showSaveEditDialog.postValue(true)
+            }
+            else -> {
+                nextStep()
+            }
         }
     }
 
@@ -297,15 +303,13 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
         return clonedTaskResultInCaseOfCancel?.let {
             val previousAnswer = it.getStepAndResult(currentStep!!.identifier).second
             return previousAnswer?.let { previousAnswerResult ->
-                previousAnswerResult.result == currentAnswer?.let { currentAnswerResult ->
-                    currentAnswerResult.result
-                } ?: false
+                previousAnswerResult.result == currentAnswer?.result ?: false
             } ?: false
         } ?: false
     }
 
 
-    private fun checkIfTheNewAnswerIsSkipWhileThePreviousIsNot(currentAnswer: StepResult<*>?): Boolean {
+    private fun checkIfNewAnswerIsSkipWhilePreviousIsNot(currentAnswer: StepResult<*>?): Boolean {
         return clonedTaskResultInCaseOfCancel?.let {
             val previousAnswer = it.getStepAndResult(currentStep!!.identifier).second
             return previousAnswer?.let { previousAnswerResult ->
@@ -318,7 +322,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
 
 
     private fun checkIfCurrentStepIsBranchDecisionStep(): Boolean {
-        var nextStep = task.getStepAfterStep(currentStep, currentTaskResult)
+        val nextStep = task.getStepAfterStep(currentStep, currentTaskResult)
         return currentTaskResult.getStepResult(nextStep.identifier) == null && !isReviewStep(nextStep)
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -284,7 +284,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     }
 
     fun checkForSaveDialog(stepResult: StepResult<*>?) {
-        if (!isSavedDialogAppeared && !checkIfAnswerAreTheSame(stepResult)) {
+        if (!isSavedDialogAppeared && !checkIfAnswersAreTheSame(stepResult)) {
             isSavedDialogAppeared = true
             showSaveEditDialog.postValue(true)
         } else {
@@ -296,7 +296,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
         isSavedDialogAppeared = false
     }
 
-    private fun checkIfAnswerAreTheSame(currentAnswer: StepResult<*>?): Boolean {
+    private fun checkIfAnswersAreTheSame(currentAnswer: StepResult<*>?): Boolean {
         return clonedTaskResultInCaseOfCancel?.let {
             val previousAnswer = it.getStepAndResult(currentStep!!.identifier).second
             return previousAnswer?.let { previousAnswerResult ->

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -263,8 +263,6 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     }
 
     fun showCancelEditAlert() {
-        val originalStepResult = clonedTaskResultInCaseOfCancel?.getStepResult(currentStep?.identifier)
-        val modifiedStepResult = taskResult.getStepResult(currentStep?.identifier)
         showCancelEditDialog.postValue(checkIfAnswersAreTheSame())
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -273,6 +273,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     }
 
     fun removeUpdatedLayout() {
+        updateCancelEditInLayout.postValue(true)
         goToReviewStep()
         stack.clear()
         editing = false

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
@@ -7,6 +7,7 @@ import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
+import android.widget.Space;
 import android.widget.TextView;
 
 
@@ -19,6 +20,7 @@ public class SubmitBar extends LinearLayout {
    //edit step bottom bar
     private TextView editSaveView;
     private TextView editCancelView;
+    private Space editSpaceView;
 
     public SubmitBar(Context context) {
         this(context, null);
@@ -48,6 +50,8 @@ public class SubmitBar extends LinearLayout {
 
         editSaveView = (TextView) findViewById(R.id.bar_submit_edit_save);
         editCancelView = (TextView) findViewById(R.id.bar_submit_edit_cancel);
+
+        editSpaceView = (Space) findViewById(R.id.edit_space_view);
 
         a.recycle();
     }
@@ -142,5 +146,9 @@ public class SubmitBar extends LinearLayout {
 
     public View getEditSaveViewActionView() {
         return editSaveView;
+    }
+
+    public View getEditSpaceView() {
+        return editSpaceView;
     }
 }

--- a/backbone/src/main/res/layout/rsb_view_submitbar.xml
+++ b/backbone/src/main/res/layout/rsb_view_submitbar.xml
@@ -8,11 +8,6 @@
     android:gravity="center_vertical"
     android:minHeight="56dp">
 
-    <Space
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1" />
-
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/bar_submit_edit_cancel"
         style="@style/Widget.AppCompat.Button.Borderless.Colored"
@@ -21,6 +16,12 @@
         android:visibility="gone"
         android:text="@string/rsb_consent_review_cancel"
         tools:text="Cancel" />
+
+    <Space
+        android:id="@+id/_space"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/bar_submit_negative"
@@ -35,6 +36,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         tools:text="Submit" />
+
+    <Space
+        android:id="@+id/edit_space_view"
+        android:layout_width="0dp"
+        android:visibility="gone"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/bar_submit_edit_save"

--- a/backbone/src/main/res/values-bg-rBG/strings.xml
+++ b/backbone/src/main/res/values-bg-rBG/strings.xml
@@ -167,5 +167,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[bg-BG] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[bg-BG] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[bg-BG] Yes, Save</string>
+    <string name="rsb_consent_review_save">[bg-BG] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-bg-rBG/strings.xml
+++ b/backbone/src/main/res/values-bg-rBG/strings.xml
@@ -168,5 +168,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[bg-BG] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[bg-BG] Yes, Save</string>
     <string name="rsb_consent_review_save">[bg-BG] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[bg-BG]Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[bg-BG] Your original response will be discarded..</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[bg-BG] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[bg-BG] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-bg-rBG/strings.xml
+++ b/backbone/src/main/res/values-bg-rBG/strings.xml
@@ -170,7 +170,7 @@
     <string name="rsb_consent_review_save">[bg-BG] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[bg-BG]Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[bg-BG] Your original response will be discarded..</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[bg-BG] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[bg-BG] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[bg-BG] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[bg-BG] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-cs-rCZ/strings.xml
+++ b/backbone/src/main/res/values-cs-rCZ/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[cs-CZ] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[cs-CZ] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[cs-CZ] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[cs-CZ] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[cs-CZ] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[cs-CZ] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[cs-CZ] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-cs-rCZ/strings.xml
+++ b/backbone/src/main/res/values-cs-rCZ/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[cs-CZ] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[cs-CZ] Yes, Save</string>
     <string name="rsb_consent_review_save">[cs-CZ] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[cs-CZ] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[cs-CZ] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[cs-CZ] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[cs-CZ] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-cs-rCZ/strings.xml
+++ b/backbone/src/main/res/values-cs-rCZ/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[cs-CZ] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[cs-CZ] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[cs-CZ] Yes, Save</string>
+    <string name="rsb_consent_review_save">[cs-CZ] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-da-rDK/strings.xml
+++ b/backbone/src/main/res/values-da-rDK/strings.xml
@@ -148,6 +148,6 @@
     <string name="rsb_consent_review_save">[da-DK] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[da-DK] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[da-DK] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[da-DK] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[da-DK] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[da-DK] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[da-DK] Yes, skip</string>
 </resources>

--- a/backbone/src/main/res/values-da-rDK/strings.xml
+++ b/backbone/src/main/res/values-da-rDK/strings.xml
@@ -145,4 +145,5 @@
     <string name="rsb_edit_step_alert_step_save_content">[da-DK] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[da-DK] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[da-DK] Yes, Save</string>
+    <string name="rsb_consent_review_save">[da-DK] Save</string>
 </resources>

--- a/backbone/src/main/res/values-da-rDK/strings.xml
+++ b/backbone/src/main/res/values-da-rDK/strings.xml
@@ -146,4 +146,8 @@
     <string name="rsb_edit_step_alert_step_save_discard">[da-DK] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[da-DK] Yes, Save</string>
     <string name="rsb_consent_review_save">[da-DK] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[da-DK] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[da-DK] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[da-DK] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[da-DK] NO, DON\'T SKIP</string>
 </resources>

--- a/backbone/src/main/res/values-de-rCH/strings.xml
+++ b/backbone/src/main/res/values-de-rCH/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[de-CH] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[de-CH] Yes, Save</string>
     <string name="rsb_consent_review_save">[de-CH] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[de-CH] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[de-CH] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[de-CH] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[de-CH] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-de-rCH/strings.xml
+++ b/backbone/src/main/res/values-de-rCH/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[de-CH] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[de-CH] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[de-CH] Yes, Save</string>
+    <string name="rsb_consent_review_save">[de-CH] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-de-rCH/strings.xml
+++ b/backbone/src/main/res/values-de-rCH/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[de-CH] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[de-CH] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[de-CH] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[de-CH] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[de-CH] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[de-CH] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[de-CH] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-de-rDE/strings.xml
+++ b/backbone/src/main/res/values-de-rDE/strings.xml
@@ -146,5 +146,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[de-DE] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[de-DE] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[de-DE] Yes, Save</string>
+    <string name="rsb_consent_review_save">[de-DE] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-de-rDE/strings.xml
+++ b/backbone/src/main/res/values-de-rDE/strings.xml
@@ -147,5 +147,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[de-DE] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[de-DE] Yes, Save</string>
     <string name="rsb_consent_review_save">[de-DE] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[de-DE] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[de-DE] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[de-DE] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[de-DE] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-de-rDE/strings.xml
+++ b/backbone/src/main/res/values-de-rDE/strings.xml
@@ -149,7 +149,7 @@
     <string name="rsb_consent_review_save">[de-DE] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[de-DE] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[de-DE] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[de-DE] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[de-DE] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[de-DE] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[de-DE] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rAU/strings.xml
+++ b/backbone/src/main/res/values-en-rAU/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[en-AU] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[en-AU] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[en-AU] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[en-AU] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[en-AU] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[en-AU] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[en-AU] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rAU/strings.xml
+++ b/backbone/src/main/res/values-en-rAU/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[en-AU] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[en-AU] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[en-AU] Yes, Save</string>
+    <string name="rsb_consent_review_save">[en-AU] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rAU/strings.xml
+++ b/backbone/src/main/res/values-en-rAU/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[en-AU] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[en-AU] Yes, Save</string>
     <string name="rsb_consent_review_save">[en-AU] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[en-AU] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[en-AU] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[en-AU] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[en-AU] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rGB/strings.xml
+++ b/backbone/src/main/res/values-en-rGB/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[en-GB] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[en-GB] Yes, Save</string>
     <string name="rsb_consent_review_save">[en-GB] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[en-GB] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[en-GB] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[en-GB] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[en-GB] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rGB/strings.xml
+++ b/backbone/src/main/res/values-en-rGB/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[en-GB] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[en-GB] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[en-GB] Yes, Save</string>
+    <string name="rsb_consent_review_save">[en-GB] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rGB/strings.xml
+++ b/backbone/src/main/res/values-en-rGB/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[en-GB] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[en-GB] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[en-GB] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[en-GB] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[en-GB] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[en-GB] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[en-GB] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rNZ/strings.xml
+++ b/backbone/src/main/res/values-en-rNZ/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[en-NZ] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[en-NZ] Yes, Save</string>
     <string name="rsb_consent_review_save">[en-NZ] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[en-NZ] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[en-NZ] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[en-NZ] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[en-NZ] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rNZ/strings.xml
+++ b/backbone/src/main/res/values-en-rNZ/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[en-NZ] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[en-NZ] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[en-NZ] Yes, Save</string>
+    <string name="rsb_consent_review_save">[en-NZ] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-en-rNZ/strings.xml
+++ b/backbone/src/main/res/values-en-rNZ/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[en-NZ] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[en-NZ] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[en-NZ] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[en-NZ] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[en-NZ] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[en-NZ] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[en-NZ] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-es-rES/strings.xml
+++ b/backbone/src/main/res/values-es-rES/strings.xml
@@ -168,5 +168,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[es-ES] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[es-ES] Yes, Save</string>
     <string name="rsb_consent_review_save">[es-ES] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[es-ES] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[es-ES] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[es-ES] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[es-ES] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-es-rES/strings.xml
+++ b/backbone/src/main/res/values-es-rES/strings.xml
@@ -167,5 +167,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[es-ES] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[es-ES] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[es-ES] Yes, Save</string>
+    <string name="rsb_consent_review_save">[es-ES] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-es-rES/strings.xml
+++ b/backbone/src/main/res/values-es-rES/strings.xml
@@ -170,7 +170,7 @@
     <string name="rsb_consent_review_save">[es-ES] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[es-ES] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[es-ES] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[es-ES] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[es-ES] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[es-ES] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[es-ES] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-es-rMX/strings.xml
+++ b/backbone/src/main/res/values-es-rMX/strings.xml
@@ -164,7 +164,7 @@
     <string name="rsb_consent_review_save">[es-MX] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[es-MX] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[es-MX] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[es-MX] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[es-MX] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[es-MX] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[es-MX] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-es-rMX/strings.xml
+++ b/backbone/src/main/res/values-es-rMX/strings.xml
@@ -162,5 +162,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[es-MX] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[es-MX] Yes, Save</string>
     <string name="rsb_consent_review_save">[es-MX] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[es-MX] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[es-MX] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[es-MX] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[es-MX] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-es-rMX/strings.xml
+++ b/backbone/src/main/res/values-es-rMX/strings.xml
@@ -161,5 +161,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[es-MX] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[es-MX] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[es-MX] Yes, Save</string>
+    <string name="rsb_consent_review_save">[es-MX] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-es-rUS/strings.xml
+++ b/backbone/src/main/res/values-es-rUS/strings.xml
@@ -161,4 +161,5 @@
     <string name="rsb_edit_step_alert_step_save_content">[es-US] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[es-US] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[es-US] Yes, Save</string>
+    <string name="rsb_consent_review_save">[es-US] Save</string>
 </resources>

--- a/backbone/src/main/res/values-es-rUS/strings.xml
+++ b/backbone/src/main/res/values-es-rUS/strings.xml
@@ -164,6 +164,6 @@
     <string name="rsb_consent_review_save">[es-US] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[es-US] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[es-US] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[es-US] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[es-US] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[es-US] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[es-US] Yes, skip</string>
 </resources>

--- a/backbone/src/main/res/values-es-rUS/strings.xml
+++ b/backbone/src/main/res/values-es-rUS/strings.xml
@@ -162,4 +162,8 @@
     <string name="rsb_edit_step_alert_step_save_discard">[es-US] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[es-US] Yes, Save</string>
     <string name="rsb_consent_review_save">[es-US] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[es-US] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[es-US] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[es-US] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[es-US] NO, DON\'T SKIP</string>
 </resources>

--- a/backbone/src/main/res/values-fr-rBE/strings.xml
+++ b/backbone/src/main/res/values-fr-rBE/strings.xml
@@ -145,6 +145,7 @@
     <string name="rsb_edit_step_alert_step_save_content">[fr-BE] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[fr-BE] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[fr-BE] Yes, Save</string>
+    <string name="rsb_consent_review_save">[fr-BE] Save</string>
 
 </resources>
 

--- a/backbone/src/main/res/values-fr-rBE/strings.xml
+++ b/backbone/src/main/res/values-fr-rBE/strings.xml
@@ -146,6 +146,10 @@
     <string name="rsb_edit_step_alert_step_save_discard">[fr-BE] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[fr-BE] Yes, Save</string>
     <string name="rsb_consent_review_save">[fr-BE] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[fr-BE] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[fr-BE] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[fr-BE] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[fr-BE] NO, DON\'T SKIP</string>
 
 </resources>
 

--- a/backbone/src/main/res/values-fr-rBE/strings.xml
+++ b/backbone/src/main/res/values-fr-rBE/strings.xml
@@ -148,8 +148,8 @@
     <string name="rsb_consent_review_save">[fr-BE] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[fr-BE] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[fr-BE] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[fr-BE] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[fr-BE] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[fr-BE] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[fr-BE] Yes, skip</string>
 
 </resources>
 

--- a/backbone/src/main/res/values-fr-rCA/strings.xml
+++ b/backbone/src/main/res/values-fr-rCA/strings.xml
@@ -146,6 +146,10 @@
     <string name="rsb_edit_step_alert_step_save_discard">[fr-CA] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[fr-CA] Yes, Save</string>
     <string name="rsb_consent_review_save">[fr-CA] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[fr-CA] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[fr-CA] Your original response will be discarded..</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[fr-CA] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[fr-CA] NO, DON\'T SKIP</string>
 
 
 </resources>

--- a/backbone/src/main/res/values-fr-rCA/strings.xml
+++ b/backbone/src/main/res/values-fr-rCA/strings.xml
@@ -148,8 +148,8 @@
     <string name="rsb_consent_review_save">[fr-CA] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[fr-CA] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[fr-CA] Your original response will be discarded..</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[fr-CA] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[fr-CA] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[fr-CA] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[fr-CA] Yes, skip</string>
 
 
 </resources>

--- a/backbone/src/main/res/values-fr-rCA/strings.xml
+++ b/backbone/src/main/res/values-fr-rCA/strings.xml
@@ -145,6 +145,7 @@
     <string name="rsb_edit_step_alert_step_save_content">[fr-CA] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[fr-CA] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[fr-CA] Yes, Save</string>
+    <string name="rsb_consent_review_save">[fr-CA] Save</string>
 
 
 </resources>

--- a/backbone/src/main/res/values-fr-rCH/strings.xml
+++ b/backbone/src/main/res/values-fr-rCH/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[fr-CH] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[fr-CH] Yes, Save</string>
     <string name="rsb_consent_review_save">[fr-CH] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[fr-CH] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[fr-CH] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[fr-CH] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[fr-CH] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-fr-rCH/strings.xml
+++ b/backbone/src/main/res/values-fr-rCH/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[fr-CH] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[fr-CH] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[fr-CH] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[fr-CH] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[fr-CH] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[fr-CH] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[fr-CH] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-fr-rCH/strings.xml
+++ b/backbone/src/main/res/values-fr-rCH/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[fr-CH] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[fr-CH] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[fr-CH] Yes, Save</string>
+    <string name="rsb_consent_review_save">[fr-CH] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-fr-rFR/strings.xml
+++ b/backbone/src/main/res/values-fr-rFR/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[fr-FR] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[fr-FR] Yes, Save</string>
     <string name="rsb_consent_review_save">[fr-FR] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[fr-FR] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[fr-FR] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[fr-FR] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[fr-FR] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-fr-rFR/strings.xml
+++ b/backbone/src/main/res/values-fr-rFR/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[fr-FR] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[fr-FR] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[fr-FR] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[fr-FR] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[fr-FR] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[fr-FR] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[fr-FR] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-fr-rFR/strings.xml
+++ b/backbone/src/main/res/values-fr-rFR/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[fr-FR] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[fr-FR] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[fr-FR] Yes, Save</string>
+    <string name="rsb_consent_review_save">[fr-FR] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-hu-rHU/strings.xml
+++ b/backbone/src/main/res/values-hu-rHU/strings.xml
@@ -169,8 +169,8 @@
     <string name="rsb_consent_review_save">[hu-HU] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[hu-HU] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[hu-HU] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[hu-HU] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[hu-HU] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[hu-HU] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[hu-HU] Yes, skip</string>
 
 </resources>
 

--- a/backbone/src/main/res/values-hu-rHU/strings.xml
+++ b/backbone/src/main/res/values-hu-rHU/strings.xml
@@ -166,6 +166,7 @@
     <string name="rsb_edit_step_alert_step_save_content">[hu-HU] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[hu-HU] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[hu-HU] Yes, Save</string>
+    <string name="rsb_consent_review_save">[hu-HU] Save</string>
 
 </resources>
 

--- a/backbone/src/main/res/values-hu-rHU/strings.xml
+++ b/backbone/src/main/res/values-hu-rHU/strings.xml
@@ -167,6 +167,10 @@
     <string name="rsb_edit_step_alert_step_save_discard">[hu-HU] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[hu-HU] Yes, Save</string>
     <string name="rsb_consent_review_save">[hu-HU] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[hu-HU] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[hu-HU] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[hu-HU] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[hu-HU] NO, DON\'T SKIP</string>
 
 </resources>
 

--- a/backbone/src/main/res/values-it-rIT/strings.xml
+++ b/backbone/src/main/res/values-it-rIT/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[it-IT] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[it-IT] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[it-IT] Yes, Save</string>
+    <string name="rsb_consent_review_save">[it-IT] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-it-rIT/strings.xml
+++ b/backbone/src/main/res/values-it-rIT/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[it-IT] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[it-IT] Yes, Save</string>
     <string name="rsb_consent_review_save">[it-IT] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[it-IT] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[it-IT] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[it-IT] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[it-IT] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-it-rIT/strings.xml
+++ b/backbone/src/main/res/values-it-rIT/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[it-IT] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[it-IT] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[it-IT] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[it-IT] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[it-IT] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[it-IT] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[it-IT] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-nl-rBE/strings.xml
+++ b/backbone/src/main/res/values-nl-rBE/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[nl-BE] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[nl-BE] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[nl-BE] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[nl-BE] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[nl-BE] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[nl-BE] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[nl-BE] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-nl-rBE/strings.xml
+++ b/backbone/src/main/res/values-nl-rBE/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[nl-BE] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[nl-BE] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[nl-BE] Yes, Save</string>
+    <string name="rsb_consent_review_save">[nl-BE] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-nl-rBE/strings.xml
+++ b/backbone/src/main/res/values-nl-rBE/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[nl-BE] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[nl-BE] Yes, Save</string>
     <string name="rsb_consent_review_save">[nl-BE] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[nl-BE] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[nl-BE] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[nl-BE] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[nl-BE] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-nl-rNL/strings.xml
+++ b/backbone/src/main/res/values-nl-rNL/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[nl-NL] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[nl-NL] Yes, Save</string>
     <string name="rsb_consent_review_save">[nl-NL] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[nl-NL] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[nl-NL] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[nl-NL] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[nl-NL] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-nl-rNL/strings.xml
+++ b/backbone/src/main/res/values-nl-rNL/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[nl-NL] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[nl-NL] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[nl-NL] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[nl-NL] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[nl-NL] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[nl-NL] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[nl-NL] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-nl-rNL/strings.xml
+++ b/backbone/src/main/res/values-nl-rNL/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[nl-NL] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[nl-NL] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[nl-NL] Yes, Save</string>
+    <string name="rsb_consent_review_save">[nl-NL] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-pl-rPL/strings.xml
+++ b/backbone/src/main/res/values-pl-rPL/strings.xml
@@ -167,5 +167,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[pl-PL] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[pl-PL] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[pl-PL] Yes, Save</string>
+    <string name="rsb_consent_review_save">[pl-PL] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-pl-rPL/strings.xml
+++ b/backbone/src/main/res/values-pl-rPL/strings.xml
@@ -168,5 +168,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[pl-PL] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[pl-PL] Yes, Save</string>
     <string name="rsb_consent_review_save">[pl-PL] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[pl-PL] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[pl-PL] Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[pl-PL] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[pl-PL] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-pl-rPL/strings.xml
+++ b/backbone/src/main/res/values-pl-rPL/strings.xml
@@ -170,7 +170,7 @@
     <string name="rsb_consent_review_save">[pl-PL] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[pl-PL] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[pl-PL] Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[pl-PL] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[pl-PL] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[pl-PL] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[pl-PL] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-ru-rUA/strings.xml
+++ b/backbone/src/main/res/values-ru-rUA/strings.xml
@@ -162,4 +162,8 @@
     <string name="rsb_edit_step_alert_step_save_discard">[ru-UK] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[ru-UK] Yes, Save</string>
     <string name="rsb_consent_review_save">[ru-UK] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[ru-UK] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[ru-UK] Your original response will be discarded..</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[ru-UK] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[ru-UK]NO, DON\'T SKIP</string>
 </resources>

--- a/backbone/src/main/res/values-ru-rUA/strings.xml
+++ b/backbone/src/main/res/values-ru-rUA/strings.xml
@@ -161,4 +161,5 @@
     <string name="rsb_edit_step_alert_step_save_content">[ru-UK] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[ru-UK] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[ru-UK] Yes, Save</string>
+    <string name="rsb_consent_review_save">[ru-UK] Save</string>
 </resources>

--- a/backbone/src/main/res/values-ru-rUA/strings.xml
+++ b/backbone/src/main/res/values-ru-rUA/strings.xml
@@ -164,6 +164,6 @@
     <string name="rsb_consent_review_save">[ru-UK] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[ru-UK] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[ru-UK] Your original response will be discarded..</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[ru-UK] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[ru-UK]NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[ru-UK] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[ru-UK]Yes, skip</string>
 </resources>

--- a/backbone/src/main/res/values-sv-rSE/strings.xml
+++ b/backbone/src/main/res/values-sv-rSE/strings.xml
@@ -164,7 +164,7 @@
     <string name="rsb_consent_review_save">[sv-SE] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[sv-SE] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[sv-SE] Your original response will be discarded..</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[sv-SE] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[sv-SE] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[sv-SE] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[sv-SE] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-sv-rSE/strings.xml
+++ b/backbone/src/main/res/values-sv-rSE/strings.xml
@@ -161,5 +161,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[sv-SE] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[sv-SE] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[sv-SE] Yes, Save</string>
+    <string name="rsb_consent_review_save">[sv-SE] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-sv-rSE/strings.xml
+++ b/backbone/src/main/res/values-sv-rSE/strings.xml
@@ -162,5 +162,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[sv-SE] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[sv-SE] Yes, Save</string>
     <string name="rsb_consent_review_save">[sv-SE] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[sv-SE] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[sv-SE] Your original response will be discarded..</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[sv-SE] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[sv-SE] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-tr-rTR/strings.xml
+++ b/backbone/src/main/res/values-tr-rTR/strings.xml
@@ -163,6 +163,6 @@
     <string name="rsb_consent_review_save">[tr-TR] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[tr-TR] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[tr-TR] Your original response will be discarded..</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[tr-TR] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[tr-TR] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[tr-TR] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[tr-TR] Yes, skip</string>
 </resources>

--- a/backbone/src/main/res/values-tr-rTR/strings.xml
+++ b/backbone/src/main/res/values-tr-rTR/strings.xml
@@ -161,4 +161,8 @@
     <string name="rsb_edit_step_alert_step_save_discard">[tr-TR] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[tr-TR] Yes, Save</string>
     <string name="rsb_consent_review_save">[tr-TR] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[tr-TR] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[tr-TR] Your original response will be discarded..</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[tr-TR] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[tr-TR] NO, DON\'T SKIP</string>
 </resources>

--- a/backbone/src/main/res/values-tr-rTR/strings.xml
+++ b/backbone/src/main/res/values-tr-rTR/strings.xml
@@ -160,4 +160,5 @@
     <string name="rsb_edit_step_alert_step_save_content">[tr-TR] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[tr-TR] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[tr-TR] Yes, Save</string>
+    <string name="rsb_consent_review_save">[tr-TR] Save</string>
 </resources>

--- a/backbone/src/main/res/values-uk-rUA/strings.xml
+++ b/backbone/src/main/res/values-uk-rUA/strings.xml
@@ -162,4 +162,8 @@
     <string name="rsb_edit_step_alert_step_save_discard">[uk-UA] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[uk-UA] Yes, Save</string>
     <string name="rsb_consent_review_save">[uk-UA] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[uk-UA] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[uk-UA] Your original response will be discarded..</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[uk-UA] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[uk-UA] NO, DON\'T SKIP</string>
 </resources>

--- a/backbone/src/main/res/values-uk-rUA/strings.xml
+++ b/backbone/src/main/res/values-uk-rUA/strings.xml
@@ -161,4 +161,5 @@
     <string name="rsb_edit_step_alert_step_save_content">[uk-UA] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[uk-UA] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[uk-UA] Yes, Save</string>
+    <string name="rsb_consent_review_save">[uk-UA] Save</string>
 </resources>

--- a/backbone/src/main/res/values-uk-rUA/strings.xml
+++ b/backbone/src/main/res/values-uk-rUA/strings.xml
@@ -164,6 +164,6 @@
     <string name="rsb_consent_review_save">[uk-UA] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[uk-UA] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[uk-UA] Your original response will be discarded..</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[uk-UA] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[uk-UA] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[uk-UA] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[uk-UA] Yes, skip</string>
 </resources>

--- a/backbone/src/main/res/values-zh-rCN/strings.xml
+++ b/backbone/src/main/res/values-zh-rCN/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[zh-CN] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[zh-CN] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[zh-CN] Your original response will be discarded..</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[zh-CN] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[zh-CN] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[zh-CN] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[zh-CN] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values-zh-rCN/strings.xml
+++ b/backbone/src/main/res/values-zh-rCN/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[zh-CN] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[zh-CN] Yes, Save</string>
     <string name="rsb_consent_review_save">[zh-CN] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[zh-CN] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[zh-CN] Your original response will be discarded..</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[zh-CN] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[zh-CN] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-zh-rCN/strings.xml
+++ b/backbone/src/main/res/values-zh-rCN/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[zh-CN] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[zh-CN] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[zh-CN] Yes, Save</string>
+    <string name="rsb_consent_review_save">[zh-CN] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-zh-rTW/strings.xml
+++ b/backbone/src/main/res/values-zh-rTW/strings.xml
@@ -146,5 +146,9 @@
     <string name="rsb_edit_step_alert_step_save_discard">[zh-TW] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[zh-TW] Yes, Save</string>
     <string name="rsb_consent_review_save">[zh-TW] Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">[zh-TW] Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">[zh-TW] Your original response will be discarded..</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[zh-TW] YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[zh-TW] NO, DON\'T SKIP</string>
 
 </resources>

--- a/backbone/src/main/res/values-zh-rTW/strings.xml
+++ b/backbone/src/main/res/values-zh-rTW/strings.xml
@@ -145,5 +145,6 @@
     <string name="rsb_edit_step_alert_step_save_content">[zh-TW] Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">[zh-TW] No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">[zh-TW] Yes, Save</string>
+    <string name="rsb_consent_review_save">[zh-TW] Save</string>
 
 </resources>

--- a/backbone/src/main/res/values-zh-rTW/strings.xml
+++ b/backbone/src/main/res/values-zh-rTW/strings.xml
@@ -148,7 +148,7 @@
     <string name="rsb_consent_review_save">[zh-TW] Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">[zh-TW] Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">[zh-TW] Your original response will be discarded..</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">[zh-TW] YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">[zh-TW] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">[zh-TW] NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">[zh-TW] Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values/strings.xml
+++ b/backbone/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="rsb_edit_step_alert_step_save_positive">Yes, Save</string>
     <string name="rsb_edit_step_alert_step_skip_title">Do you want to skip this step?</string>
     <string name="rsb_edit_step_alert_step_skip_content">Your original response will be discarded.</string>
-    <string name="rsb_edit_step_alert_step_skip_discard">YES, SKIP</string>
-    <string name="rsb_edit_step_alert_step_skip_positive">NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">NO, DON\'T SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">Yes, skip</string>
 
 </resources>

--- a/backbone/src/main/res/values/strings.xml
+++ b/backbone/src/main/res/values/strings.xml
@@ -185,5 +185,9 @@
     <string name="rsb_edit_step_alert_step_save_content">Other responses may be cleared and you may be asked to submit new information.</string>
     <string name="rsb_edit_step_alert_step_save_discard">No, Discard</string>
     <string name="rsb_edit_step_alert_step_save_positive">Yes, Save</string>
+    <string name="rsb_edit_step_alert_step_skip_title">Do you want to skip this step?</string>
+    <string name="rsb_edit_step_alert_step_skip_content">Your original response will be discarded.</string>
+    <string name="rsb_edit_step_alert_step_skip_discard">YES, SKIP</string>
+    <string name="rsb_edit_step_alert_step_skip_positive">NO, DON\'T SKIP</string>
 
 </resources>


### PR DESCRIPTION
### Objective
Add Save Dialog to alert users before saving new answer. please notice that in branching task, the alert will be shown in the first step only ( branching decision step )

### How to Test
Click on update step button (pencil) in the Review step, change your answer and click save, the save dialog will appear 