### PR TITLE
PAT-1462 fixed showing confirmation dialog when cancelling edit for unchanged step

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/result/Result.java
+++ b/backbone/src/main/java/org/researchstack/backbone/result/Result.java
@@ -108,9 +108,7 @@ public class Result implements Serializable {
         }
         final Result result = (Result) o;
         return saveable == result.saveable &&
-                Objects.equals(getIdentifier(), result.getIdentifier()) &&
-                Objects.equals(getStartDate(), result.getStartDate()) &&
-                Objects.equals(getEndDate(), result.getEndDate());
+                Objects.equals(getIdentifier(), result.getIdentifier());
     }
 
     @Override

--- a/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
+++ b/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
@@ -144,6 +144,9 @@ public class StepResult<T> extends Result implements Cloneable {
             boolean isCloned = false;
             if (e.getValue() instanceof Cloneable) {
                 try {
+                    // This is going to clone any object of the type Cloneable, This is inevitable because we need to
+                    // clone every answer in the results map in order to able to make changes to the original object
+                    // without affecting the cloned one.
                     Method method = e.getValue().getClass().getDeclaredMethod("clone");
                     method.setAccessible(true);
 

--- a/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
+++ b/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
@@ -6,6 +6,8 @@ import org.researchstack.backbone.answerformat.AnswerFormat;
 import org.researchstack.backbone.step.QuestionStep;
 import org.researchstack.backbone.step.Step;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -124,8 +126,7 @@ public class StepResult<T> extends Result implements Cloneable {
             return false;
         }
         final StepResult<?> result = (StepResult<?>) other;
-        return Objects.equals(getResults(), result.getResults()) &&
-                Objects.equals(getAnswerFormat(), result.getAnswerFormat());
+        return Objects.equals(getResults(), result.getResults());
     }
 
     @Override
@@ -139,13 +140,28 @@ public class StepResult<T> extends Result implements Cloneable {
         StepResult cloned = (StepResult) super.clone();
 
         cloned.results = new HashMap<>();
-        for (Map.Entry<String, T> e : results.entrySet())
-            cloned.results.put(e.getKey(), e.getValue());
+        for (Map.Entry<String, T> e : results.entrySet()) {
+            boolean isCloned = false;
+            if (e.getValue() instanceof Cloneable) {
+                try {
+                    Method method = e.getValue().getClass().getDeclaredMethod("clone");
+                    method.setAccessible(true);
+
+                    cloned.results.put(e.getKey(), method.invoke(e.getValue()));
+                    isCloned = true;
+                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ex) {
+                    ex.printStackTrace();
+                }
+            }
+            if (!isCloned) {
+                cloned.results.put(e.getKey(), e.getValue());
+            }
+        }
 
         cloned.answerFormat = answerFormat;
-        cloned.setStartDate(new Date());
+        cloned.setStartDate((Date) getStartDate().clone());
         // this will be updated when the result is set
-        cloned.setEndDate(new Date());
+        cloned.setEndDate((Date) getEndDate().clone());
         return cloned;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -219,6 +219,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         }
 
         submitBar.setEditCancelAction(view -> {
+            stepBody.getStepResult(isSkipped);
             callbacks.onEditCancelStep();
         });
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -67,15 +67,20 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
         }
 
         observe(viewModel.showEditDialog) {
-            showAlertDialog(
-                    R.string.rsb_task_cancel_title,
-                    R.string.rsb_edit_step_alert_cancel_title,
-                    R.string.rsb_edit_step_alert_cancel_discard,
-                    R.string.rsb_edit_step_alert_cancel_save,
-                    {
-                        it.dismiss()
-                        viewModel.cancelEditDismiss()
-                    }, { viewModel.removeUpdatedLayout() }) }
+            if (it) {
+                showAlertDialog(R.string.rsb_task_cancel_title,
+                        R.string.rsb_edit_step_alert_cancel_title,
+                        R.string.rsb_edit_step_alert_cancel_discard,
+                        R.string.rsb_edit_step_alert_cancel_positive,
+                        {
+                            it.dismiss()
+                            viewModel.cancelEditDismiss()
+                        },
+                        { viewModel.removeUpdatedLayout() })
+            } else {
+                viewModel.removeUpdatedLayout()
+            }
+        }
 
         observe(viewModel.editStep) {
             navController.navigate(it.destinationId)

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.MutableLiveData
 import org.researchstack.backbone.R
 import org.researchstack.backbone.result.StepResult
 import org.researchstack.backbone.result.TaskResult
+import org.researchstack.backbone.step.FormStep
 import org.researchstack.backbone.step.Step
 import org.researchstack.backbone.task.Task
 import org.researchstack.backbone.ui.SingleLiveEvent
@@ -263,9 +264,11 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
         return results
     }
 
-
     fun showCancelEditAlert() {
-        showEditDialog.postValue(true)
+        val originalStepResult = clonedTaskResultInCaseOfCancel?.getStepResult(currentStep?.identifier)
+        val modifiedStepResult = taskResult.getStepResult(currentStep?.identifier)
+        var showDialog = originalStepResult?.equals(modifiedStepResult)?.not()
+        showEditDialog.postValue(showDialog)
     }
 
     fun cancelEditDismiss() {


### PR DESCRIPTION
### Objective
- Fixed PAT-1462 - [ReviewStep] Cancel editing should not show dialog if there are no changes.

### How
- How:
  - By keeping track of the changes and comparing the original object with the changed one.
  - Had to add some code to make sure we are cloning `StepResult` in a correct way.
  - By setting `TaskResult` to the changed values in case of Form step

### How To Test
- Credentials:
  - Environment: Int-dev
  - Org: abdallahandela
  - Study: Banadol

- Steps:
  1- Open Patient App
  2- Use the credentials above
  3- Join Study
  4- Start task "ReviewStep Boolean"
  5- Take all steps until you reach to ReviewStep
  6- Edit any of the steps
  7- Tap Cancel

**Note:** Please make sure you test this scenario with Form Step as well, as it is treated differently.

- Expected:
Cancel button should take us right back to ReviewStep

- Actual:
A dialog is showing asking the user to confirm cancellation.

##### Branches
- PAT: bug/PAT-1462_fix_show_dialog_when_cancelling_unchanged_step_edit
- Axon: bug/PAT-1462_fix_show_dialog_when_cancelling_unchanged_step_edit
- RS: bug/PAT-1462_fix_show_dialog_when_cancelling_unchanged_step_edit
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1462

Closes PAT-1462