### PR TITLE
PAT-1475 Block screenshots for dev and prod but not automatedFlask

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -43,7 +43,7 @@ android {
         }
 
         dev {
-            buildConfigField 'boolean', 'USE_SECURE_FLAG', 'false'
+            buildConfigField 'boolean', 'USE_SECURE_FLAG', 'true'
         }
 
         automatedFlask {


### PR DESCRIPTION
PAT-1475

 Block screenshots for dev and prod but not for automatedFlask.
Test:
* Checkout https://gitlab.medable.com/axon/android/sdk/merge_requests/575
* Try to take a screenshot inside of a Task
* Verify that it doesn't let you take a screenshot