### PR TITLE
PAT-1476 : Fix Edit view not working in Autocomplete, Image Capture s…

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -55,10 +55,12 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
                         viewModel.colorPrimary, viewModel.colorSecondary, viewModel.principalTextColor,
                         viewModel.secondaryTextColor)
                 stepView.isStepEmpty.observe(this, Observer { })
+                setupStepCallbacks(stepView)
 
             }
             is StepLayout -> {
                 stepView.initialize(currentStep, stepResult)
+                setupStepCallbacks(stepView)
             }
             is ConsentVisualStepLayout -> stepView.initialize(currentStep, stepResult,
                     viewModel.colorPrimary, viewModel.colorSecondary, viewModel.principalTextColor,
@@ -68,17 +70,18 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
             }
         }
 
-        if (stepView is StepLayout) {
-            stepView.setCallbacks(this)
-            stepView.isEditView(viewModel.editing)
-            viewModel.updateCancelEditInLayout.observe(this, Observer {
-                stepView.setCancelEditMode(it)
-            })
+    }
 
-            viewModel.stepBackNavigationState.observe(this, Observer {
-                stepView.setRemoveFromBackStack(it)
-            })
-        }
+    private fun setupStepCallbacks(stepView: StepLayout) {
+        stepView.setCallbacks(this)
+        stepView.isEditView(viewModel.editing)
+        viewModel.updateCancelEditInLayout.observe(this, Observer {
+            stepView.setCancelEditMode(it)
+        })
+
+        viewModel.stepBackNavigationState.observe(this, Observer {
+            stepView.setRemoveFromBackStack(it)
+        })
     }
 
     override fun onSaveStep(action: Int, step: Step, result: StepResult<*>?) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -32,7 +32,7 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
         super.onResume()
 
         val currentStep = viewModel.currentStep
-        val stepResult =  viewModel.currentTaskResult.getStepResult(currentStep?.identifier)
+        val stepResult = viewModel.currentTaskResult.getStepResult(currentStep?.identifier)
 
         currentStep?.setStepTheme(viewModel.colorPrimary, viewModel.colorPrimaryDark, viewModel.colorSecondary,
                 viewModel.principalTextColor, viewModel.secondaryTextColor, viewModel.actionFailedColor)
@@ -48,27 +48,17 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
             }
 
         }
-
-        when (val stepView = view?.findViewById<View>(R.id.stepView)) {
+        val stepView = view?.findViewById<View>(R.id.stepView)
+        when (stepView) {
             is SurveyStepLayout -> {
                 stepView.initialize(currentStep, stepResult,
                         viewModel.colorPrimary, viewModel.colorSecondary, viewModel.principalTextColor,
                         viewModel.secondaryTextColor)
                 stepView.isStepEmpty.observe(this, Observer { })
-                stepView.setCallbacks(this)
-                stepView.isEditView(viewModel.editing)
 
-                viewModel.updateCancelEditInLayout.observe(this, Observer {
-                    stepView.setCancelEditMode(it)
-                })
-
-                viewModel.stepBackNavigationState.observe(this, Observer {
-                    stepView.setRemoveFromBackStack(it)
-                })
             }
             is StepLayout -> {
                 stepView.initialize(currentStep, stepResult)
-                stepView.setCallbacks(this)
             }
             is ConsentVisualStepLayout -> stepView.initialize(currentStep, stepResult,
                     viewModel.colorPrimary, viewModel.colorSecondary, viewModel.principalTextColor,
@@ -76,6 +66,18 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
             else -> {
                 Log.d("BaseStepFragment", "WARNING: Unknown stepView type, cannot initialize layout")
             }
+        }
+
+        if (stepView is StepLayout) {
+            stepView.setCallbacks(this)
+            stepView.isEditView(viewModel.editing)
+            viewModel.updateCancelEditInLayout.observe(this, Observer {
+                stepView.setCancelEditMode(it)
+            })
+
+            viewModel.stepBackNavigationState.observe(this, Observer {
+                stepView.setRemoveFromBackStack(it)
+            })
         }
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -48,8 +48,7 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
             }
 
         }
-        val stepView = view?.findViewById<View>(R.id.stepView)
-        when (stepView) {
+        when (val stepView = view?.findViewById<View>(R.id.stepView)) {
             is SurveyStepLayout -> {
                 stepView.initialize(currentStep, stepResult,
                         viewModel.colorPrimary, viewModel.colorSecondary, viewModel.principalTextColor,

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
@@ -83,6 +83,16 @@ public class ConsentDocumentStepLayout extends LinearLayout implements StepLayou
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 
+    @Override
+    public void setRemoveFromBackStack(boolean removeFromBackStack) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
+    @Override
+    public void isEditView(boolean isEditView) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
     private void initializeStep() {
         setOrientation(VERTICAL);
         LayoutInflater.from(getContext()).inflate(R.layout.rsb_step_layout_consent_doc, this, true);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -78,6 +78,16 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
         //no-op only when user on edit mode inside regular steps
     }
 
+    @Override
+    public void setRemoveFromBackStack(boolean removeFromBackStack) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
+    @Override
+    public void isEditView(boolean isEditView) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
     private void initializeStep() {
         LayoutInflater.from(getContext()).inflate(R.layout.rsb_step_layout_consent_signature, this, true);
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
@@ -82,6 +82,16 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
     }
 
     @Override
+    public void setRemoveFromBackStack(boolean removeFromBackStack) {
+        //no-op only when user on edit mode inside regular steps
+    }
+
+    @Override
+    public void isEditView(boolean isEditView) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
+    @Override
     public int getContentResourceId() {
         return R.layout.rsb_step_layout_consent_visual;
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -62,6 +62,16 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
     }
 
     @Override
+    public void setRemoveFromBackStack(boolean removeFromBackStack) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
+    @Override
+    public void isEditView(boolean isEditView) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
+    @Override
     public int getContentResourceId() {
         return R.layout.rsb_step_layout_instruction;
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
@@ -21,4 +21,8 @@ public interface StepLayout {
     void setCallbacks(StepCallbacks callbacks);
 
     void setCancelEditMode(boolean isCancelEdit);
+
+    void setRemoveFromBackStack(boolean removeFromBackStack);
+
+    void isEditView(boolean isEditView);
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -157,20 +157,10 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         submitBar.setPositiveTitle(text);
     }
 
-
+    @Override
     public void isEditView(boolean isEditView) {
         isEditViewVisible = isEditView;
-        if (isEditView) {
-            submitBar.getPositiveActionView().setVisibility(GONE);
-            submitBar.getEditCancelViewActionView().setVisibility(VISIBLE);
-            submitBar.getEditSaveViewActionView().setVisibility(VISIBLE);
-            submitBar.getEditSpaceView().setVisibility(VISIBLE);
-        } else {
-            submitBar.getPositiveActionView().setVisibility(VISIBLE);
-            submitBar.getEditCancelViewActionView().setVisibility(GONE);
-            submitBar.getEditSaveViewActionView().setVisibility(GONE);
-            submitBar.getEditSpaceView().setVisibility(GONE);
-        }
+        submitBar.updateView(isEditView);
     }
 
     public void initStepLayout() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
@@ -95,7 +95,7 @@ public class SubmitBar extends LinearLayout {
 
     public void setPositiveActionDisabled() {
         positiveView.setClickable(false);
-        positiveView.setTextColor(getResources().getColor(R.color.rsb_submit_disabled));
+        positiveView.setTextColor(getContext().getColor(R.color.rsb_submit_disabled));
 
     }
 
@@ -174,7 +174,7 @@ public class SubmitBar extends LinearLayout {
 
     public void setEditSaveActionDisabled() {
         editSaveView.setClickable(false);
-        editSaveView.setTextColor(getResources().getColor(R.color.rsb_submit_disabled));
+        editSaveView.setTextColor(getContext().getColor(R.color.rsb_submit_disabled));
 
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
@@ -17,7 +17,7 @@ public class SubmitBar extends LinearLayout {
     private TextView positiveView;
     private TextView negativeView;
 
-   //edit step bottom bar
+    //edit step bottom bar
     private TextView editSaveView;
     private TextView editCancelView;
     private Space editSpaceView;
@@ -150,5 +150,19 @@ public class SubmitBar extends LinearLayout {
 
     public View getEditSpaceView() {
         return editSpaceView;
+    }
+
+    public void updateView(boolean isEditView) {
+        if (isEditView) {
+            getPositiveActionView().setVisibility(GONE);
+            getEditCancelViewActionView().setVisibility(VISIBLE);
+            getEditSaveViewActionView().setVisibility(VISIBLE);
+            getEditSpaceView().setVisibility(VISIBLE);
+        } else {
+            getPositiveActionView().setVisibility(VISIBLE);
+            getEditCancelViewActionView().setVisibility(GONE);
+            getEditSaveViewActionView().setVisibility(GONE);
+            getEditSpaceView().setVisibility(GONE);
+        }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
@@ -165,4 +165,16 @@ public class SubmitBar extends LinearLayout {
             getEditSpaceView().setVisibility(GONE);
         }
     }
+
+    public void setEditSaveActionEnabled(int color) {
+        editSaveView.setClickable(true);
+        editSaveView.setTextColor(color);
+
+    }
+
+    public void setEditSaveActionDisabled() {
+        editSaveView.setClickable(false);
+        editSaveView.setTextColor(getResources().getColor(R.color.rsb_submit_disabled));
+
+    }
 }


### PR DESCRIPTION
### Objective
Fixing edit mode on Auto complete, Image capture, Barcode Steps

### Description
Qa's were not able to test Auto complete, Image capture, Barcode Steps since the edit mode where not implemented on those steps, when they press on the pencil they will see the targeted test but editable 

Related to this tickets 

- https://jira.devops.medable.com/browse/PAT-1469
- https://jira.devops.medable.com/browse/PAT-1470
- https://jira.devops.medable.com/browse/PAT-1476

### How to test?
- Org: abdallahandela
- Study: Banadol
- Task : Auto Complete Task

**Steps**

1. Answers all the steps until you reach Reach to ReviewStep
2. Hit on the pencil button on AutoComplete Step or Barcode Step or ImageCapture Step
3. Then change your answers **save** it or **skip** it or **cancel** the step if you need to, and see if everything is working as intended 