### PR TITLE
PAT-1498: Fix equals for StepResult to include AnswerFormat.

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
+++ b/backbone/src/main/java/org/researchstack/backbone/result/StepResult.java
@@ -128,8 +128,9 @@ public class StepResult<T> extends Result implements Cloneable {
         if (!super.equals(other)) {
             return false;
         }
-        final StepResult<?> result = (StepResult<?>) other;
-        return Objects.equals(getResults(), result.getResults());
+        final StepResult<?> that = (StepResult<?>) other;
+        return Objects.equals(getResults(), that.getResults()) &&
+                Objects.equals(getAnswerFormat(), that.getAnswerFormat());
     }
 
     @Override


### PR DESCRIPTION
### Objective
* Ensure equals/hashCode behaves as expected when comparing `StepResult` objects.

### How to test
* Axon MR will include this change and use it in a Unit Test. Nothing to do here.

