### PR TITLE
PAT-1500: Adding image text under ImageChoice image in ReviewStep

### DIFF
--- a/backbone/src/main/res/layout/rsb_image_choice_step_layout.xml
+++ b/backbone/src/main/res/layout/rsb_image_choice_step_layout.xml
@@ -55,6 +55,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/imageChoiceStepImageBarrier"
         android:layout_marginStart="16dp"
+        android:contentDescription="@null"
         app:srcCompat="@drawable/rsb_ic_circle_8dp" />
 
     <TextView

--- a/backbone/src/main/res/layout/rsb_image_choice_step_layout.xml
+++ b/backbone/src/main/res/layout/rsb_image_choice_step_layout.xml
@@ -38,7 +38,7 @@
         app:layout_constraintTop_toTopOf="@id/reviewStepEditButtonBottomBarrier" />
 
     <TextView
-        android:id="@+id/imageChoiceStepQuestionAnswer"
+        android:id="@+id/imageChoiceStepQuestionSkipped"
         style="@style/rsb_review_step_sub_step_answer_style"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -48,14 +48,30 @@
         app:layout_constraintTop_toBottomOf="@id/imageChoiceStepImageBarrier"
         tools:text="Yes" />
 
-    <ImageView
-        android:id="@+id/imageChoiceImageStepQuestionAnswer"
-        style="@style/rsb_image_choice_step_style"
+    <LinearLayout
+        android:id="@+id/imageChoiceImageStepAnswerContainer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/imageChoiceStepImageBarrier"
-        app:srcCompat="@drawable/rsb_ic_circle_8dp" />
+        app:layout_constraintTop_toBottomOf="@id/imageChoiceStepImageBarrier">
+
+        <ImageView
+            android:id="@+id/imageChoiceImageStepQuestionAnswer"
+            style="@style/rsb_image_choice_step_style"
+            android:layout_gravity="center_horizontal"
+            app:srcCompat="@drawable/rsb_ic_circle_8dp" />
+
+        <TextView
+            android:id="@+id/imageChoiceStepQuestionAnswer"
+            style="@style/rsb_review_step_sub_step_answer_style"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:background="@null" />
+    </LinearLayout>
 
     <include layout="@layout/rsb_review_step_edit_button_layout" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/backbone/src/main/res/layout/rsb_image_choice_step_layout.xml
+++ b/backbone/src/main/res/layout/rsb_image_choice_step_layout.xml
@@ -48,30 +48,25 @@
         app:layout_constraintTop_toBottomOf="@id/imageChoiceStepImageBarrier"
         tools:text="Yes" />
 
-    <LinearLayout
-        android:id="@+id/imageChoiceImageStepAnswerContainer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:orientation="vertical"
+    <ImageView
+        android:id="@+id/imageChoiceImageStepQuestionAnswer"
+        style="@style/rsb_image_choice_step_style"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/imageChoiceStepImageBarrier">
+        app:layout_constraintTop_toBottomOf="@id/imageChoiceStepImageBarrier"
+        android:layout_marginStart="16dp"
+        app:srcCompat="@drawable/rsb_ic_circle_8dp" />
 
-        <ImageView
-            android:id="@+id/imageChoiceImageStepQuestionAnswer"
-            style="@style/rsb_image_choice_step_style"
-            android:layout_gravity="center_horizontal"
-            app:srcCompat="@drawable/rsb_ic_circle_8dp" />
-
-        <TextView
-            android:id="@+id/imageChoiceStepQuestionAnswer"
-            style="@style/rsb_review_step_sub_step_answer_style"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:background="@null" />
-    </LinearLayout>
+    <TextView
+        android:id="@+id/imageChoiceStepQuestionAnswer"
+        style="@style/rsb_review_step_sub_step_answer_style"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/imageChoiceImageStepQuestionAnswer"
+        app:layout_constraintStart_toStartOf="@id/imageChoiceImageStepQuestionAnswer"
+        app:layout_constraintEnd_toEndOf="@id/imageChoiceImageStepQuestionAnswer"
+        android:gravity="center_horizontal"
+        android:background="@null" />
 
     <include layout="@layout/rsb_review_step_edit_button_layout" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/backbone/src/main/res/values/styles.xml
+++ b/backbone/src/main/res/values/styles.xml
@@ -132,7 +132,6 @@
     <style name="rsb_image_choice_step_style">
         <item name="android:layout_width">100dp</item>
         <item name="android:layout_height">100dp</item>
-        <item name="android:layout_marginStart">16dp</item>
         <item name="android:scaleType">fitCenter</item>
    </style>
     <style name="rsb_image_capture_step_style">


### PR DESCRIPTION
### Objective
- Adding ImageChoice text under the selected image in the ReviewStep

### How To Test
**Context information**
Environment: QA
Org: Hybridstudy
Study: QA - Regression
User: angela+q33@medable.com/qpal1010

**Location**
This bug happens in the Image choice task

**Bug description**
When user is on the Review step, it is not displaying the Image text for selected images.

**Steps:**
1) Launch PAT APP
2) Login study of precond
3) Select Task: T11 - Image Choice
4) Complete all the steps and reach Review step

**Actual result**
Notice that it is not displaying the Image text for selected images.

**Expected result**
It should display tthe Image text for selected images
(See zeplin design)
https://app.zeplin.io/project/5d8e16c2db3c0d61aac43a5f/screen/5da0bfe5ae6da730a33d983a


##### Branches
- PAT: development
- Axon: bug/PAT-1500_ImageChoice_text_not_displayed
- RS: bug/PAT-1500_ImageChoice_text_not_displayed
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1500

Closes PAT-1500