### PR TITLE
PAT-1508: Resolved crash when editing steps with branching logic

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -111,7 +111,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
             }
 
 
-            if (isReviewStep(nextStep)) {
+            if (isReviewStep(nextStep) || isCompletionStep(nextStep)) {
                 clonedTaskResult?.let {
                     taskResult = updateTaskResultsFrom(it)
                 }
@@ -228,6 +228,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     }
 
     private fun isReviewStep(step: Step) = step::class.java.simpleName.contains("RSReviewStep", true)
+    private fun isCompletionStep(step: Step) = step::class.java.simpleName.contains("RSCompletionStep", true)
 
     companion object {
         const val TAG = "TaskViewModel"


### PR DESCRIPTION
### Objective
- Fixed PAT-1508 app is crashing when editing steps with branching logic

### How
- By checking if the next step is `RSCompletionStep`, it should follow the same approach as `RSReviewStep`

### How To Test
**Context information**
Environment: QA
Org: Hybridstudy
Study: QA - Regression
User: angela+q33@medable.com/qpal1010
**Task:** https://app.qa.medable.com/hybridstudy/axon/study/5c76bc486ce0200100f8e68f/task/5dadb526f8332101005cf79e

**Location**
This bug happens in the any task with branching logic

**Bug description**
When user edits a step using a branching logic, the app is crashing.

**Preconditions:**
Have a step with a branch configured

**Steps:**
1) Launch PAT APP
2) Login study QA-Regression
3) Select Task: Branching task PAT-1508- do not modify
4) Select Yes and click Next --> Review step
5) Select edit next to Yes option
6) Select No and Next(Fail)
7) Select Next in the Completion step

**Note:** this is happening with any task following this logic.
**Actual result**
Notice that app is crashing when completing the Completion step.

**Expected result**
App should not crash and complete the task as expected.

##### Branches
- PAT: development
- Axon: bug/PAT-1508_crash_edit_step_with_branches
- RS: bug/PAT-1508_crash_edit_step_with_branches
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1508

Closes PAT-1508