### PR TITLE
PAT-1484: Date/Time User is able to enter an invalid time and tap next

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -32,8 +32,6 @@ import org.researchstack.backbone.utils.TextUtils;
 
 import java.lang.reflect.Constructor;
 
-import static org.researchstack.backbone.ui.callbacks.StepCallbacks.ACTION_SAVE;
-
 public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout {
     public static final String TAG = SurveyStepLayout.class.getSimpleName();
 
@@ -177,7 +175,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         submitBar.setEditCancelColor(coloryPrimary);
         submitBar.setEditSaveColor(colorSecondary);
         submitBar.setPositiveAction(view -> {
-            if (onNextClicked()) {
+            if (onNextClicked(StepCallbacks.ACTION_NEXT)) {
                 submitBar.clearActions();
             }
         });
@@ -219,9 +217,9 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         });
 
         submitBar.setEditSaveAction(view -> {
-            isSkipped = false;
-            callbacks.onSaveStep(ACTION_SAVE, getStep(),
-                    stepBody.getStepResult(isSkipped));
+            if (onNextClicked(StepCallbacks.ACTION_SAVE)) {
+                submitBar.clearActions();
+            }
         });
     }
 
@@ -267,7 +265,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         return super.onSaveInstanceState();
     }
 
-    protected boolean onNextClicked() {
+    private boolean onNextClicked(int action) {
         BodyAnswer bodyAnswer = stepBody.getBodyAnswerState();
 
         if (bodyAnswer == null || !bodyAnswer.isValid()) {
@@ -279,7 +277,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
             return false;
         } else {
             isSkipped = false;
-            callbacks.onSaveStep(StepCallbacks.ACTION_NEXT,
+            callbacks.onSaveStep(action,
                     getStep(),
                     stepBody.getStepResult(isSkipped));
             return true;


### PR DESCRIPTION
### Objective
- Fixed PAT-1484: Having invalid Date/Time in an optional step doesn't prevent the user to go to next step.

### How To Test
**Context information**

Environment: Int-Dev

Org: abdallahandela

Study: Banadol

**Steps:**
1. Join Study
2. Select task "ReviewStep DateTime"
3. Reach step 'Optional with Min and Max'
4. Tap on the field and select 2019-12-31 07:00 AM
5. Tap 'OK'
6. Verify error message is displayed
7. Tap on 'Next'

**Actual result**
Next button is functional and takes you to the next step which shows the step result as "Skipped"

**Expected result**
Next button shouldn't take the user to next screen and show a toast instead

**Note:** Please make sure this works when you edit this Date/Time step

##### Branches
- PAT: development
- Axon: bug/PAT-1484_DateTime_invalid_time_is_accepted
- RS: bug/PAT-1484_DateTime_invalid_time_is_accepted
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1484

Closes PAT-1484