### PR TITLE
PAT-1468: Form: when updating location permissions, the form is cleaned up

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -111,4 +111,11 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
             it.setDisplayHomeAsUpEnabled(setVisible)
         }
     }
+
+    fun saveCurrentStepResult() {
+        val stepView = view?.findViewById<View>(R.id.stepView)
+        if (viewModel.currentStep != null && stepView is StepLayout) {
+            onSaveStep(StepCallbacks.ACTION_NONE, viewModel.currentStep!!, stepView.stepResult)
+        }
+    }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
@@ -93,6 +93,11 @@ public class ConsentDocumentStepLayout extends LinearLayout implements StepLayou
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 
+    @Override
+    public StepResult getStepResult() {
+        return stepResult;
+    }
+
     private void initializeStep() {
         setOrientation(VERTICAL);
         LayoutInflater.from(getContext()).inflate(R.layout.rsb_step_layout_consent_doc, this, true);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -88,6 +88,11 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 
+    @Override
+    public StepResult getStepResult() {
+        return result;
+    }
+
     private void initializeStep() {
         LayoutInflater.from(getContext()).inflate(R.layout.rsb_step_layout_consent_signature, this, true);
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
@@ -93,6 +93,7 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
 
     @Override
     public StepResult getStepResult() {
+        // This step doesn't have a result, so we're returning null instead
         return null;
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
@@ -92,6 +92,11 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
     }
 
     @Override
+    public StepResult getStepResult() {
+        return null;
+    }
+
+    @Override
     public int getContentResourceId() {
         return R.layout.rsb_step_layout_consent_visual;
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -73,6 +73,7 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
 
     @Override
     public StepResult getStepResult() {
+        // This step doesn't have a result, so we're returning null instead
         return null;
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -72,6 +72,11 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
     }
 
     @Override
+    public StepResult getStepResult() {
+        return null;
+    }
+
+    @Override
     public int getContentResourceId() {
         return R.layout.rsb_step_layout_instruction;
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
@@ -25,4 +25,6 @@ public interface StepLayout {
     void setRemoveFromBackStack(boolean removeFromBackStack);
 
     void isEditView(boolean isEditView);
+
+    StepResult getStepResult();
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
@@ -26,5 +26,8 @@ public interface StepLayout {
 
     void isEditView(boolean isEditView);
 
+    /**
+     * @return StepResult for a step even if it's not yet saved
+     */
     StepResult getStepResult();
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -161,6 +161,11 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         submitBar.updateView(isEditView);
     }
 
+    @Override
+    public StepResult getStepResult() {
+        return stepBody.getStepResult(isSkipped);
+    }
+
     public void initStepLayout() {
         LogExt.i(getClass(), "initStepLayout()");
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -33,6 +33,7 @@ import org.researchstack.backbone.ui.PinCodeActivity
 import org.researchstack.backbone.ui.permissions.PermissionListener
 import org.researchstack.backbone.ui.permissions.PermissionMediator
 import org.researchstack.backbone.ui.permissions.PermissionResult
+import org.researchstack.backbone.ui.step.fragments.BaseStepFragment
 import org.researchstack.backbone.ui.step.layout.StepLayout
 import org.researchstack.backbone.ui.step.layout.SurveyStepLayout
 import org.researchstack.backbone.utils.ViewUtils
@@ -180,13 +181,22 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
 
     override fun requestPermissions(permissionListener: PermissionListener, vararg permissions:
     String?) {
+        saveCurrentStepResult()
         stepPermissionListener = permissionListener
         requestPermissions(permissions, STEP_PERMISSION_LISTENER_REQUEST)
     }
 
     @RequiresApi(Build.VERSION_CODES.M)
     override fun requestPermissions(vararg permissions: String?) {
+        saveCurrentStepResult()
         requestPermissions(permissions, STEP_PERMISSION_REQUEST)
+    }
+
+    private fun saveCurrentStepResult() {
+        val fragment = getCurrentFragment()
+        if (fragment is BaseStepFragment) {
+            fragment.saveCurrentStepResult()
+        }
     }
 
     // TODO: this should be handled by each fragment/step/type that needs any sort of permission


### PR DESCRIPTION
### Objective
- Fixed PAT-1468: Form: when updating location permissions, the form is cleaned up

### How To Test
**Context information**
Environment: QA
Org: Hybridstudy
Study: QA - Regression
User: angela+q33@medable.com

**Bug description**
When user updates location permissions on a form, the completed fields are cleaned up.

**Video link**
https://drive.google.com/open?id=1exwLskc0bueTnm3oRUnTXxmSDITmmfVV

**Steps:**
1) Launch PAT APP
2) Login study of precond
3) Select T08- Form
4) Complete all the fields
5) In the location step, allow permissions

**Actual result**
Notice that completed fields are cleaned up in the form

**Expected result**
Completed fields should remain with selected information.

### Branches
- PAT: development
- Axon: bug/PAT-1468_Update_permission_clears_form
- RS: bug/PAT-1468_Update_permission_clears_form
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1468

Closes PAT-1468