### PR TITLE
PAT-1486: When going back to step, previous answers not saved

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -19,7 +19,7 @@ import org.researchstack.backbone.ui.task.TaskViewModel
 internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment(contentLayoutId), StepCallbacks {
 
     override fun onSkipStep(step: Step?, originalStepResult: StepResult<*>?, modifiedStepResult: StepResult<*>?) {
-        viewModel.checkForSkipDialog(originalStepResult, modifiedStepResult)
+        viewModel.checkForSkipDialog(modifiedStepResult)
     }
 
     override fun onEditCancelStep() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -19,7 +19,7 @@ import org.researchstack.backbone.ui.task.TaskViewModel
 internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment(contentLayoutId), StepCallbacks {
 
     override fun onSkipStep(step: Step?, originalStepResult: StepResult<*>?, modifiedStepResult: StepResult<*>?) {
-        viewModel.checkForSkipDialog(originalStepResult)
+        viewModel.checkForSkipDialog(originalStepResult, modifiedStepResult)
     }
 
     override fun onEditCancelStep() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -8,7 +8,6 @@ import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import androidx.preference.PreferenceManager
 import android.view.Menu
 import android.view.MenuItem
 import android.view.WindowManager
@@ -22,6 +21,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigation
+import androidx.preference.PreferenceManager
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.Theme
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -109,7 +109,10 @@ class TaskActivity : PinCodeActivity(), PermissionMediator {
                     {
                         it.dismiss()
                         viewModel.saveEditDialogDismiss()
-                    }, { viewModel.nextStep() })
+                    }, {
+                viewModel.clearBranchingResults()
+                viewModel.nextStep()
+            })
         }
 
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -320,9 +320,10 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
         }
     }
 
-    fun checkForSkipDialog(originalStepResult: StepResult<*>?) {
+    fun checkForSkipDialog(originalStepResult: StepResult<*>?,
+                           modifiedStepResult: StepResult<*>?) {
         when {
-            currentStep!!.isOptional && checkIfNewAnswerIsSkipWhilePreviousIsNot() -> {
+            currentStep!!.isOptional && checkIfNewAnswerIsSkipWhilePreviousIsNot(originalStepResult, modifiedStepResult) -> {
                 showSkipEditDialog.postValue(Pair(true, originalStepResult!!))
             }
             else -> {
@@ -343,13 +344,13 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     }
 
     @VisibleForTesting
-    fun checkIfNewAnswerIsSkipWhilePreviousIsNot(): Boolean {
-        val originalStepResult = clonedTaskResultInCaseOfCancel?.getStepResult(currentStep?.identifier)
-        val modifiedStepResult = currentTaskResult.getStepResult(currentStep?.identifier)
-        return if (originalStepResult == null) {
+    fun checkIfNewAnswerIsSkipWhilePreviousIsNot(originalStepResult: StepResult<*>?,
+                                                 modifiedStepResult: StepResult<*>?): Boolean {
+        return if (originalStepResult == null || originalStepResult.results.isEmpty()) {
+            currentTaskResult.setStepResultForStep(currentStep!!, modifiedStepResult)
             false
         } else {
-            originalStepResult.allValuesAreNull()!!.not() && modifiedStepResult.allValuesAreNull()
+            originalStepResult.allValuesAreNull()!!.not() && modifiedStepResult!!.allValuesAreNull()
         }
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -134,18 +134,18 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
         } else {
             val nextStep = task.getStepAfterStep(currentStep, taskResult)
 
-            // This checks if the nextStep doesn't have a result and clears all results starting from that step
-            // This is useful in a branching task in case we go back to a certain step, and then go forward again,
-            // this will ensure that if another branch is taken, all next step results will be cleared.
-            // Note: The first check is a workaround that checks if the task is not an OrderedTask, and so it's a
-            // BranchManagedTask (which can't be accessed from ResearchStack so we can't check it directly).
-            if (task !is OrderedTask && taskResult.getStepResult(nextStep.identifier) == null) {
-                clearBranchingResults()
-            }
-
             if (nextStep == null) {
                 close(true)
             } else {
+                // This checks if the nextStep doesn't have a result and clears all results starting from that step
+                // This is useful in a branching task in case we go back to a certain step, and then go forward again,
+                // this will ensure that if another branch is taken, all next step results will be cleared.
+                // Note: The first check is a workaround that checks if the task is not an OrderedTask, and so it's a
+                // BranchManagedTask (which can't be accessed from ResearchStack so we can't check it directly).
+                if (task !is OrderedTask && taskResult.getStepResult(nextStep.identifier) == null) {
+                    clearBranchingResults()
+                }
+
                 currentStep = nextStep
 
                 if (nextStep.isHidden) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -2,7 +2,6 @@ package org.researchstack.backbone.ui.task
 
 import android.app.Application
 import android.content.Intent
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
@@ -347,7 +346,11 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     fun checkIfNewAnswerIsSkipWhilePreviousIsNot(): Boolean {
         val originalStepResult = clonedTaskResultInCaseOfCancel?.getStepResult(currentStep?.identifier)
         val modifiedStepResult = currentTaskResult.getStepResult(currentStep?.identifier)
-        return originalStepResult?.allValuesAreNull()!!.not() && modifiedStepResult.allValuesAreNull()
+        return if (originalStepResult == null) {
+            false
+        } else {
+            originalStepResult.allValuesAreNull()!!.not() && modifiedStepResult.allValuesAreNull()
+        }
     }
 
     @VisibleForTesting

--- a/backbone/src/test/java/org/researchstack/backbone/ui/task/TaskViewModelTest.kt
+++ b/backbone/src/test/java/org/researchstack/backbone/ui/task/TaskViewModelTest.kt
@@ -299,7 +299,7 @@ class TaskViewModelTest {
         `when`(clonedTaskResultInCaseOfCancel!!.getStepResult(any())).thenReturn(originalStepResult)
         `when`(currentTaskResult!!.getStepResult(any())).thenReturn(modifiedStepResult)
 
-        taskViewModel.clonedTaskResultInCaseOfCancel = clonedTaskResultInCaseOfCancel
+        taskViewModel.clonedTaskResultInCaseOfEdit = clonedTaskResultInCaseOfCancel
         taskViewModel.taskResult = currentTaskResult!!
     }
 

--- a/backbone/src/test/java/org/researchstack/backbone/ui/task/TaskViewModelTest.kt
+++ b/backbone/src/test/java/org/researchstack/backbone/ui/task/TaskViewModelTest.kt
@@ -265,12 +265,14 @@ class TaskViewModelTest {
         currentStepMocked.isOptional = true
         doReturn(true).`when`(taskViewModel).checkIfNewAnswerIsSkipWhilePreviousIsNot(any(), any())
         val modifiedStepResult = createStepResult(null)
+        val originalStepResult = createStepResult("tow")
+        addStepResultIntoMockedMethods(originalStepResult, originalStepResult)
 
         //act
-        taskViewModel.checkForSkipDialog(originalStepResult, modifiedStepResult)
+        taskViewModel.checkForSkipDialog(modifiedStepResult)
 
         //Assert
-        Assert.assertEquals(taskViewModel.showSkipEditDialog.value, Pair(true, originalStepResult!!))
+        Assert.assertEquals(taskViewModel.showSkipEditDialog.value, Pair(true, originalStepResult))
     }
 
     @Test
@@ -281,10 +283,10 @@ class TaskViewModelTest {
         val modifiedStepResult = createStepResult(null)
 
         //act
-        taskViewModel.checkForSkipDialog(originalStepResult, modifiedStepResult)
+        taskViewModel.checkForSkipDialog(modifiedStepResult)
 
         //Assert
-        verify(taskViewModel).checkForSkipDialog(originalStepResult, modifiedStepResult)
+        verify(taskViewModel).checkForSkipDialog(modifiedStepResult)
         verify(taskViewModel).nextStep()
         verify(taskViewModel).currentStep = any() // called in setUp
         verifyNoMoreInteractions(taskViewModel)

--- a/backbone/src/test/java/org/researchstack/backbone/ui/task/TaskViewModelTest.kt
+++ b/backbone/src/test/java/org/researchstack/backbone/ui/task/TaskViewModelTest.kt
@@ -154,10 +154,11 @@ class TaskViewModelTest {
     @Test
     fun checkIfNewAnswerIsSkipWhilePreviousAnswersIsNot_ShouldReturnTrue() {
         // Assemble
-        createAndFillStepResult("one", null)
+        val originalStepResult = createStepResult("text")
+        val modifiedStepResult = createStepResult(null)
 
         // Act
-        val actualResult = taskViewModel.checkIfNewAnswerIsSkipWhilePreviousIsNot()
+        val actualResult = taskViewModel.checkIfNewAnswerIsSkipWhilePreviousIsNot(originalStepResult, modifiedStepResult)
 
         // Assert
         Assert.assertEquals(actualResult, true)
@@ -166,10 +167,11 @@ class TaskViewModelTest {
     @Test
     fun checkIfNewAnswerIsSkipWhilePreviousAnswersIsNot_ShouldReturnFalse() {
         // Assemble
-        createAndFillStepResult("one", "tow")
+        val originalStepResult = createStepResult(null)
+        val modifiedStepResult = createStepResult(null)
 
         // Act
-        val actualResult = taskViewModel.checkIfNewAnswerIsSkipWhilePreviousIsNot()
+        val actualResult = taskViewModel.checkIfNewAnswerIsSkipWhilePreviousIsNot(originalStepResult, modifiedStepResult)
 
         // Assert
         Assert.assertEquals(actualResult, false)
@@ -261,7 +263,8 @@ class TaskViewModelTest {
     fun whenNewAnswerIsSkipWhilePreviousIsNot_And_StepIsOptional_ShouldShowSkipDialog() {
         // Assemble
         currentStepMocked.isOptional = true
-        doReturn(true).`when`(taskViewModel).checkIfNewAnswerIsSkipWhilePreviousIsNot()
+        doReturn(true).`when`(taskViewModel).checkIfNewAnswerIsSkipWhilePreviousIsNot(any(), any())
+        val modifiedStepResult = createStepResult(null)
 
         //act
         taskViewModel.checkForSkipDialog(originalStepResult, modifiedStepResult)
@@ -275,11 +278,13 @@ class TaskViewModelTest {
         // Assemble
         doNothing().`when`(taskViewModel).nextStep()
         currentStepMocked.isOptional = false
+        val modifiedStepResult = createStepResult(null)
+
         //act
         taskViewModel.checkForSkipDialog(originalStepResult, modifiedStepResult)
 
         //Assert
-        verify(taskViewModel).checkForSkipDialog(any(), modifiedStepResult)
+        verify(taskViewModel).checkForSkipDialog(originalStepResult, modifiedStepResult)
         verify(taskViewModel).nextStep()
         verify(taskViewModel).currentStep = any() // called in setUp
         verifyNoMoreInteractions(taskViewModel)

--- a/backbone/src/test/java/org/researchstack/backbone/ui/task/TaskViewModelTest.kt
+++ b/backbone/src/test/java/org/researchstack/backbone/ui/task/TaskViewModelTest.kt
@@ -264,7 +264,7 @@ class TaskViewModelTest {
         doReturn(true).`when`(taskViewModel).checkIfNewAnswerIsSkipWhilePreviousIsNot()
 
         //act
-        taskViewModel.checkForSkipDialog(originalStepResult)
+        taskViewModel.checkForSkipDialog(originalStepResult, modifiedStepResult)
 
         //Assert
         Assert.assertEquals(taskViewModel.showSkipEditDialog.value, Pair(true, originalStepResult!!))
@@ -276,10 +276,10 @@ class TaskViewModelTest {
         doNothing().`when`(taskViewModel).nextStep()
         currentStepMocked.isOptional = false
         //act
-        taskViewModel.checkForSkipDialog(originalStepResult)
+        taskViewModel.checkForSkipDialog(originalStepResult, modifiedStepResult)
 
         //Assert
-        verify(taskViewModel).checkForSkipDialog(any())
+        verify(taskViewModel).checkForSkipDialog(any(), modifiedStepResult)
         verify(taskViewModel).nextStep()
         verify(taskViewModel).currentStep = any() // called in setUp
         verifyNoMoreInteractions(taskViewModel)


### PR DESCRIPTION
### Objective
- Fixed PAT-1486: When going back to step, previous answers not saved

### How To Test
**Context information**
Environment: QA
Org: Hybridstudy
Study: QA Regression

**Bug description**
When a user is on the Numeric review step and then goes back to previous steps, the values previously entered are not saved.

**Steps**
1) Launch the Pat App
2) Login to QA regression
3) Select T14- Numeric task
4) Complete all the steps and reach Review step
5) Select back until S01
6) Click Next

**Actual Result:**
Previously entered values are not saved, after optional step.

**Expected Result:**
Previously entered values should be saved.

**Note:** Please make sure you test this with a branching task as well.

### Branches
- PAT: development
- Axon: development
- RS: bug/PAT-1486_Fix_step_results_when_going_back_and_forward
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1486

Closes PAT-1486