### PR TITLE
PAT-1593: Various ReviewStep UX fixes

### DIFF
--- a/backbone/src/main/res/drawable/rsb_form_step_reviewstep_rect.xml
+++ b/backbone/src/main/res/drawable/rsb_form_step_reviewstep_rect.xml
@@ -3,6 +3,6 @@
     android:shape="rectangle">
 
     <stroke
-        android:width="1dp"
+        android:width="@dimen/rsb_reviewStep_form_border_width"
         android:color="@color/rsb_concrete" />
 </shape>

--- a/backbone/src/main/res/layout/rsb_form_section_step_layout.xml
+++ b/backbone/src/main/res/layout/rsb_form_section_step_layout.xml
@@ -4,14 +4,28 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="8dp">
+    android:paddingTop="8dp"
+    android:paddingBottom="0dp">
 
     <TextView
         android:id="@+id/formSectionStepQuestionTitle"
         style="@style/rsb_review_step_form_step_section_title_style"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Continuous Scale Step Title" />
+
+        tools:text="Form Section Title" />
+
+    <View
+        android:id="@+id/formSectionStepDividerLine"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:background="@color/rsb_concrete"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/formSectionStepQuestionTitle" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/backbone/src/main/res/layout/rsb_form_section_step_layout.xml
+++ b/backbone/src/main/res/layout/rsb_form_section_step_layout.xml
@@ -8,7 +8,7 @@
 
     <TextView
         android:id="@+id/formSectionStepQuestionTitle"
-        style="@style/rsb_review_step_sub_step_title_style"
+        style="@style/rsb_review_step_form_step_section_title_style"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"

--- a/backbone/src/main/res/layout/rsb_form_step_layout.xml
+++ b/backbone/src/main/res/layout/rsb_form_step_layout.xml
@@ -43,6 +43,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="@drawable/rsb_form_step_reviewstep_rect"
+        android:paddingStart="@dimen/rsb_reviewStep_form_border_width"
+        android:paddingEnd="@dimen/rsb_reviewStep_form_border_width"
         android:visibility="visible"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintEnd_toEndOf="parent"

--- a/backbone/src/main/res/layout/rsb_review_step_edit_button_layout.xml
+++ b/backbone/src/main/res/layout/rsb_review_step_edit_button_layout.xml
@@ -31,5 +31,6 @@
         app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:paddingBottom="8dp"
         tools:ignore="HardcodedText" />
 </merge>

--- a/backbone/src/main/res/values/dimens.xml
+++ b/backbone/src/main/res/values/dimens.xml
@@ -24,5 +24,8 @@
     <dimen name="rsb_reviewStep_item_title_bottom_margin">13dp</dimen>
     <dimen name="rsb_reviewStep_form_border_width">1.5dp</dimen>
 
+    <dimen name="rsb_reviewStep_item_top_margin">30dp</dimen>
+    <dimen name="rsb_reviewStep_item_top_margin_in_form">10dp</dimen>
+    <dimen name="rsb_reviewStep_section_item_top_margin_in_form">2dp</dimen>
 
 </resources>

--- a/backbone/src/main/res/values/dimens.xml
+++ b/backbone/src/main/res/values/dimens.xml
@@ -1,31 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <!-- Padding -->
     <dimen name="rsb_padding_small">8dp</dimen>
     <dimen name="rsb_padding_wedge">12dp</dimen>
     <dimen name="rsb_padding_medium">16dp</dimen>
     <dimen name="rsb_padding_large">24dp</dimen>
-
     <!-- Item Height -->
     <dimen name="rsb_item_size_small">48dp</dimen>
     <dimen name="rsb_item_size_medium">56dp</dimen>
     <dimen name="rsb_item_size_default">@dimen/rsb_item_size_small</dimen>
     <dimen name="rsb_item_size_divider">1dp</dimen>
-
     <!-- Item Margin -->
     <dimen name="rsb_margin_top">16dp</dimen>
     <dimen name="rsb_margin_left">16dp</dimen>
     <dimen name="rsb_margin_right">16dp</dimen>
-
     <!-- Text Size -->
     <dimen name="rsb_text_size_title">35sp</dimen>
     <dimen name="rsb_text_size_summary">18sp</dimen>
-
     <!-- ReviewStep Dimensions -->
     <dimen name="rsb_reviewStep_item_bottom_padding">10dp</dimen>
     <dimen name="rsb_reviewStep_item_question_bottom_padding">10dp</dimen>
+    <dimen name="rsb_reviewStep_item_answer_line_spacing_multiplier">1.2</dimen>
     <dimen name="rsb_reviewStep_item_title_bottom_margin">13dp</dimen>
+    <dimen name="rsb_reviewStep_form_border_width">1.5dp</dimen>
 
 
 </resources>

--- a/backbone/src/main/res/values/styles.xml
+++ b/backbone/src/main/res/values/styles.xml
@@ -168,6 +168,12 @@
         <item name="android:paddingEnd">8dp</item>
     </style>
 
+    <style name="rsb_review_step_form_step_section_title_style">
+        <item name="android:textColor">@color/rsb_black</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="rsb_review_step_sub_step_title_style">
         <item name="android:textColor">@color/rsb_black</item>
         <item name="android:textSize">18sp</item>

--- a/backbone/src/main/res/values/styles.xml
+++ b/backbone/src/main/res/values/styles.xml
@@ -174,6 +174,12 @@
         <item name="android:textStyle">bold</item>
     </style>
 
+    <style name="rsb_review_step_form_sub_step_title_style">
+        <item name="android:textColor">@color/rsb_black</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="rsb_review_step_sub_step_title_style">
         <item name="android:textColor">@color/rsb_black</item>
         <item name="android:textSize">18sp</item>

--- a/backbone/src/main/res/values/styles.xml
+++ b/backbone/src/main/res/values/styles.xml
@@ -194,6 +194,7 @@
         <item name="android:paddingEnd">8dp</item>
         <item name="android:textSize">16sp</item>
         <item name="android:textStyle">bold</item>
+        <item name="android:lineSpacingMultiplier">@dimen/rsb_reviewStep_item_answer_line_spacing_multiplier</item>
     </style>
 
 </resources>


### PR DESCRIPTION
### Objective
* Adjust the ReviewStep UX to match the new Zeplin comps and fix some inconsistencies.

### Description
* The bulk of this work ended up being the new change to display the Titles of "Sub Steps" (where SubStep is just a regular step but inside a FormStep). Previously when a step was in a FormStep, the title was not rendered by the ReviewStep app. Now it has to be rendered. 
* The FormSection view holder (a section *only* used inside FormSteps), also changed appearances and now has a divider line. 
* The TypeValueResolver abstraction was removed, and all DP values were added to the Resources/Dimensions and extracted from there. All unit tests were updated to reflect this. 
* The spacing between multi-line answers was adjusted (via lineMultiplier) and the thickness of the FormStep container border has been increased. 

### How to Test
If you are up to the challenge:

1. `int-dev` | `neurus` | `ReviewStep` -> Task: `One Of Each` (log in with `test@ing.com` | `qpal1010`)
2. Complete or skip as many steps as you want and reach review step. 
3. Observe the[ comps in Zeplin](https://app.zeplin.io/project/5d8e16c2db3c0d61aac43a5f/dashboard) if you feel adventurous
4. Simply observe the steps don't do anything stupid. 

### BRANCHES
This MR is nothing without the Axon counterpart (and PAT).

* PAT: `bug/PAT-1593_review_step_ux_fixes`
* AXON: `bug/PAT-1593_review_step_ux_fixes`
* RS: `bug/PAT-1593_review_step_ux_fixes`
* Cortex: `development`


