### PR TITLE
PAT-1564: Save button always visible when editing a step

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DateQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DateQuestionBody.java
@@ -210,6 +210,8 @@ public class DateQuestionBody implements StepBody {
                         showTimePicker(tv);
                     }
                     isStepEmpty.postValue(false);
+                    result.setResult(calendar.getTimeInMillis());
+                    modifiedStepResult.postValue(result);
                 }
         );
         if (tv.getContext() instanceof FragmentActivity) {
@@ -228,6 +230,8 @@ public class DateQuestionBody implements StepBody {
                     // Set result to our edit text
                     String formattedResult = createFormattedResult();
                     tv.setText(formattedResult);
+                    result.setResult(calendar.getTimeInMillis());
+                    modifiedStepResult.postValue(result);
                 },
                 defaultHour,
                 defaultMinute,

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DecimalQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DecimalQuestionBody.java
@@ -1,7 +1,9 @@
 package org.researchstack.backbone.ui.step.body;
 
 import android.content.Context;
+import android.text.Editable;
 import android.text.InputFilter;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -65,6 +67,7 @@ public class DecimalQuestionBody implements StepBody {
     private View initViewDefault(LayoutInflater inflater, ViewGroup parent) {
         editText = (EditText) inflater.inflate(R.layout.rsb_item_edit_text, parent, false);
         setFilters(parent.getContext());
+        initListeners();
 
         return editText;
     }
@@ -77,6 +80,7 @@ public class DecimalQuestionBody implements StepBody {
 
         editText = (EditText) formItemView.findViewById(R.id.value);
         setFilters(parent.getContext());
+        initListeners();
 
         return formItemView;
     }
@@ -109,6 +113,27 @@ public class DecimalQuestionBody implements StepBody {
         InputFilter.LengthFilter maxLengthFilter = new InputFilter.LengthFilter(maxLength);
         InputFilter[] newFilters = ViewUtils.addFilter(editText.getFilters(), maxLengthFilter);
         editText.setFilters(newFilters);
+    }
+
+    private void initListeners() {
+        editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                isStepEmpty.postValue(s.length() == 0);
+                result.setResult(Float.valueOf(editText.getText().toString()));
+                modifiedStepResult.postValue(result);
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+
+            }
+        });
     }
 
     @Override

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DurationQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DurationQuestionBody.java
@@ -3,6 +3,7 @@ package org.researchstack.backbone.ui.step.body;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
@@ -92,6 +93,14 @@ public class DurationQuestionBody implements StepBody {
             hoursSpinner.setSelection(result / 60);
             minutesSpinner.setSelection(result % 60);
         }
+        AdapterView.OnItemClickListener onItemClickListener = (parent1, view, position, id) -> {
+            int hours = hoursSpinner.getSelectedItemPosition();
+            int minutes = minutesSpinner.getSelectedItemPosition();
+            this.result.setResult((hours * 60) + minutes);
+            modifiedStepResult.postValue(this.result);
+        };
+        minutesSpinner.setOnItemClickListener(onItemClickListener);
+        hoursSpinner.setOnItemClickListener(onItemClickListener);
 
         return v;
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
@@ -104,4 +104,8 @@ public class FormBody implements StepBody {
     public List<QuestionStep> getQuestionSteps() {
         return questionSteps;
     }
+
+    public List<StepBody> getFormStepChildren() {
+        return formStepChildren;
+    }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/IntegerQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/IntegerQuestionBody.java
@@ -1,7 +1,9 @@
 package org.researchstack.backbone.ui.step.body;
 
 import android.content.Context;
+import android.text.Editable;
 import android.text.InputFilter;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -49,6 +51,27 @@ public class IntegerQuestionBody implements StepBody {
                 ViewGroup.LayoutParams.WRAP_CONTENT);
         view.setLayoutParams(layoutParams);
 
+        editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                isStepEmpty.postValue(s.length() == 0);
+                String numString = editText.getText().toString();
+                if (!TextUtils.isEmpty(numString)) {
+                    result.setResult(Integer.valueOf(editText.getText().toString()));
+                }
+                modifiedStepResult.postValue(result);
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+
+            }
+        });
         return view;
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/MultiChoiceQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/MultiChoiceQuestionBody.java
@@ -96,6 +96,8 @@ public class MultiChoiceQuestionBody<T> implements StepBody {
                 } else {
                     currentSelected.remove(item.getValue());
                 }
+                result.setResult((T[]) currentSelected.toArray());
+                modifiedStepResult.postValue(result);
             });
         }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/SingleChoiceQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/SingleChoiceQuestionBody.java
@@ -88,6 +88,8 @@ public class SingleChoiceQuestionBody<T> implements StepBody {
         radioGroup.setOnCheckedChangeListener((group, checkedId) -> {
             Choice<T> choice = choices[checkedId];
             currentSelected = choice.getValue();
+            result.setResult(currentSelected);
+            modifiedStepResult.postValue(result);
         });
 
         return radioGroup;

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/StepBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/StepBody.java
@@ -13,6 +13,8 @@ public interface StepBody {
     int VIEW_TYPE_COMPACT = 1;
     MutableLiveData<Boolean> isStepEmpty = new MutableLiveData<>();
 
+    MutableLiveData<StepResult> modifiedStepResult = new MutableLiveData<>();
+
     View getBodyView(int viewType, LayoutInflater inflater, ViewGroup parent);
 
     StepResult getStepResult(boolean skipped);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/TextQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/TextQuestionBody.java
@@ -63,6 +63,7 @@ public class TextQuestionBody implements StepBody {
         // Set result on text change
         RxTextView.textChanges(editText).subscribe(text -> {
             result.setResult(text.toString());
+            modifiedStepResult.postValue(result);
         });
 
         // Format EditText from TextAnswerFormat

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -70,6 +70,8 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
 
     private fun setupStepCallbacks(stepView: StepLayout) {
         stepView.setCallbacks(this)
+        val originalStepResult = viewModel.getOriginalStepResultBeforeEdit()
+        stepView.setOriginalStepResult(originalStepResult)
         stepView.isEditView(viewModel.editing)
         viewModel.updateCancelEditInLayout.observe(this, Observer {
             stepView.setCancelEditMode(it)

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
@@ -98,6 +98,11 @@ public class ConsentDocumentStepLayout extends LinearLayout implements StepLayou
         return stepResult;
     }
 
+    @Override
+    public void setOriginalStepResult(StepResult originalStepResult) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
     private void initializeStep() {
         setOrientation(VERTICAL);
         LayoutInflater.from(getContext()).inflate(R.layout.rsb_step_layout_consent_doc, this, true);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
@@ -2,6 +2,8 @@ package org.researchstack.backbone.ui.step.layout;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.lifecycle.MutableLiveData;
+
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -99,7 +101,13 @@ public class ConsentDocumentStepLayout extends LinearLayout implements StepLayou
     }
 
     @Override
-    public void setOriginalStepResult(StepResult originalStepResult) {
+    public MutableLiveData<StepResult> getModifiedStepResultLiveData() {
+        // This step doesn't support editing, so we're returning null LiveData
+        return null;
+    }
+
+    @Override
+    public void updateSubmitBarSaveVisibility(boolean visible) {
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -93,6 +93,11 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
         return result;
     }
 
+    @Override
+    public void setOriginalStepResult(StepResult originalStepResult) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
     private void initializeStep() {
         LayoutInflater.from(getContext()).inflate(R.layout.rsb_step_layout_consent_signature, this, true);
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -3,6 +3,8 @@ package org.researchstack.backbone.ui.step.layout;
 import android.content.Context;
 import android.graphics.Bitmap;
 import androidx.appcompat.widget.AppCompatTextView;
+import androidx.lifecycle.MutableLiveData;
+
 import android.util.AttributeSet;
 import android.util.Base64;
 import android.view.LayoutInflater;
@@ -94,7 +96,13 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
     }
 
     @Override
-    public void setOriginalStepResult(StepResult originalStepResult) {
+    public MutableLiveData<StepResult> getModifiedStepResultLiveData() {
+        // This step doesn't support editing, so we're returning null LiveData
+        return null;
+    }
+
+    @Override
+    public void updateSubmitBarSaveVisibility(boolean visible) {
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.lifecycle.MutableLiveData;
+
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageView;
@@ -95,6 +97,17 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
     public StepResult getStepResult() {
         // This step doesn't have a result, so we're returning null instead
         return null;
+    }
+
+    @Override
+    public MutableLiveData<StepResult> getModifiedStepResultLiveData() {
+        // This step doesn't have a result, so we're returning null LiveData instead
+        return null;
+    }
+
+    @Override
+    public void updateSubmitBarSaveVisibility(boolean visible) {
+        //no-op only when user on edit mode inside regular steps
     }
 
     @Override

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -7,6 +7,8 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.lifecycle.MutableLiveData;
+
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ResourcePathManager;
 import org.researchstack.backbone.result.StepResult;
@@ -75,6 +77,17 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
     public StepResult getStepResult() {
         // This step doesn't have a result, so we're returning null instead
         return null;
+    }
+
+    @Override
+    public MutableLiveData<StepResult> getModifiedStepResultLiveData() {
+        // This step doesn't have a result, so we're returning null LiveData instead
+        return null;
+    }
+
+    @Override
+    public void updateSubmitBarSaveVisibility(boolean visible) {
+        //no-op only when user on edit mode inside regular steps
     }
 
     @Override

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
@@ -2,6 +2,8 @@ package org.researchstack.backbone.ui.step.layout;
 
 import android.view.View;
 
+import androidx.lifecycle.MutableLiveData;
+
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.ui.callbacks.StepCallbacks;
@@ -31,5 +33,7 @@ public interface StepLayout {
      */
     StepResult getStepResult();
 
-    void setOriginalStepResult(StepResult originalStepResult);
+    MutableLiveData<StepResult> getModifiedStepResultLiveData();
+
+    void updateSubmitBarSaveVisibility(boolean visible);
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
@@ -30,4 +30,6 @@ public interface StepLayout {
      * @return StepResult for a step even if it's not yet saved
      */
     StepResult getStepResult();
+
+    void setOriginalStepResult(StepResult originalStepResult);
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -1,12 +1,8 @@
 package org.researchstack.backbone.ui.step.layout;
 
-import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MediatorLiveData;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Parcelable;
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 import android.text.Html;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -14,6 +10,11 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ResourcePathManager;
@@ -159,6 +160,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
     public void isEditView(boolean isEditView) {
         isEditViewVisible = isEditView;
         submitBar.updateView(isEditView);
+        updateSaveButton(originalStepResult);
     }
 
     @Override
@@ -238,6 +240,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         }
         stepBody = createStepBody(questionStep, stepResult);
         mediator.addSource(stepBody.isStepEmpty, this::isStepEmpty);
+        mediator.addSource(stepBody.modifiedStepResult, this::updateSaveButton);
 
         View body = stepBody.getBodyView(StepBody.VIEW_TYPE_DEFAULT, inflater, this);
 
@@ -328,6 +331,11 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
             submitBar.setPositiveActionDisabled();
         }
 
+    }
+
+    private void updateSaveButton(StepResult currentStepResult) {
+        boolean isEnabled = originalStepResult == null || !originalStepResult.equals(currentStepResult);
+        submitBar.getEditSaveViewActionView().setEnabled(isEnabled);
     }
 
     private void checkIfAllStepsAreOptional() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -237,6 +237,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         submitBar.setPositiveActionEnabled(getStep().getColorSecondary());
         if (stepBody != null) {
             mediator.removeSource(stepBody.isStepEmpty);
+            mediator.removeSource(stepBody.modifiedStepResult);
         }
         stepBody = createStepBody(questionStep, stepResult);
         mediator.addSource(stepBody.isStepEmpty, this::isStepEmpty);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -15,6 +15,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MediatorLiveData;
+import androidx.lifecycle.MutableLiveData;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ResourcePathManager;
@@ -160,7 +161,6 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
     public void isEditView(boolean isEditView) {
         isEditViewVisible = isEditView;
         submitBar.updateView(isEditView);
-        updateSaveButton(originalStepResult);
     }
 
     @Override
@@ -237,11 +237,9 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         submitBar.setPositiveActionEnabled(getStep().getColorSecondary());
         if (stepBody != null) {
             mediator.removeSource(stepBody.isStepEmpty);
-            mediator.removeSource(stepBody.modifiedStepResult);
         }
         stepBody = createStepBody(questionStep, stepResult);
         mediator.addSource(stepBody.isStepEmpty, this::isStepEmpty);
-        mediator.addSource(stepBody.modifiedStepResult, this::updateSaveButton);
 
         View body = stepBody.getBodyView(StepBody.VIEW_TYPE_DEFAULT, inflater, this);
 
@@ -334,9 +332,14 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
     }
 
-    private void updateSaveButton(StepResult currentStepResult) {
-        boolean isEnabled = originalStepResult == null || !originalStepResult.equals(currentStepResult);
-        submitBar.getEditSaveViewActionView().setEnabled(isEnabled);
+    @Override
+    public MutableLiveData<StepResult> getModifiedStepResultLiveData() {
+        return stepBody.modifiedStepResult;
+    }
+
+    @Override
+    public void updateSubmitBarSaveVisibility(boolean visible) {
+        submitBar.getEditSaveViewActionView().setVisibility(visible ? View.VISIBLE : View.GONE);
     }
 
     private void checkIfAllStepsAreOptional() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -353,8 +353,8 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
         }
     }
 
-    fun getOriginalStepResultBeforeEdit(): StepResult<*>? {
-        return clonedTaskResultInCaseOfEdit?.getStepResult(currentStep?.identifier)
+    fun getOriginalStepResultForId(identifier: String?): StepResult<*>? {
+        return clonedTaskResultInCaseOfEdit?.getStepResult(identifier)
     }
 
     @VisibleForTesting

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -336,7 +336,6 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
         isSavedDialogAppeared = false
     }
 
-    @VisibleForTesting
     fun checkIfAnswersAreTheSame(): Boolean {
         val originalStepResult = clonedTaskResultInCaseOfEdit?.getStepResult(currentStep?.identifier)
         val modifiedStepResult = currentTaskResult.getStepResult(currentStep?.identifier)
@@ -352,6 +351,10 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
         } else {
             originalStepResult.allValuesAreNull()!!.not() && modifiedStepResult!!.allValuesAreNull()
         }
+    }
+
+    fun getOriginalStepResultBeforeEdit(): StepResult<*>? {
+        return clonedTaskResultInCaseOfEdit?.getStepResult(currentStep?.identifier)
     }
 
     @VisibleForTesting

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/FixedSubmitBarLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/FixedSubmitBarLayout.java
@@ -6,11 +6,14 @@ import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import org.researchstack.backbone.R;
+import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.ui.step.layout.StepLayout;
 
 import androidx.constraintlayout.widget.ConstraintLayout;
 
 public abstract class FixedSubmitBarLayout extends ConstraintLayout implements StepLayout {
+    protected StepResult originalStepResult;
+
     public FixedSubmitBarLayout(Context context) {
         super(context);
         init();
@@ -36,5 +39,14 @@ public abstract class FixedSubmitBarLayout extends ConstraintLayout implements S
         // Add contentContainer to the layout
         ViewGroup contentContainer = findViewById(R.id.rsb_content_container);
         inflater.inflate(getContentResourceId(), contentContainer, true);
+    }
+
+    @Override
+    public void setOriginalStepResult(StepResult originalStepResult) {
+        this.originalStepResult = originalStepResult;
+    }
+
+    public StepResult getOriginalStepResult() {
+        return originalStepResult;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/FixedSubmitBarLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/FixedSubmitBarLayout.java
@@ -6,14 +6,11 @@ import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import org.researchstack.backbone.R;
-import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.ui.step.layout.StepLayout;
 
 import androidx.constraintlayout.widget.ConstraintLayout;
 
 public abstract class FixedSubmitBarLayout extends ConstraintLayout implements StepLayout {
-    protected StepResult originalStepResult;
-
     public FixedSubmitBarLayout(Context context) {
         super(context);
         init();
@@ -39,14 +36,5 @@ public abstract class FixedSubmitBarLayout extends ConstraintLayout implements S
         // Add contentContainer to the layout
         ViewGroup contentContainer = findViewById(R.id.rsb_content_container);
         inflater.inflate(getContentResourceId(), contentContainer, true);
-    }
-
-    @Override
-    public void setOriginalStepResult(StepResult originalStepResult) {
-        this.originalStepResult = originalStepResult;
-    }
-
-    public StepResult getOriginalStepResult() {
-        return originalStepResult;
     }
 }


### PR DESCRIPTION
### Objective
- Fixed PAT-1564: Save button always visible when editing a step

### How To Test
**Credentials:**
- Environment: Int-Dev
- Org: abdallahandela
- Study: Banadol

**Steps:**
  1. Open the app and use the credentials above
  2. Join Study
  3. Take any task
  4. Reach to ReviewStep
  5. Edit any step (except webview because this fix doesn't include webviews)
  6. Change the value for the step (do not save)

**Expected:**
1. Before changing the value, the save button should not be visible.
2. After changing the value, the save button should be visible.
3. If the user selects the initial value, the save button should not be visible

### Branches
- PAT: development
- Axon: bug/PAT-1564_save_button_always_enabled
- RS: bug/PAT-1564_save_button_always_enabled
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1564

Closes PAT-1564