### PR TITLE
PAT-1700: Fixed editing any step type before GoogleFitPermission step

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -103,7 +103,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
             }
             var nextStep = task.getStepAfterStep(currentStep, currentTaskResult)
             // Current step with branches?
-            hasBranching = clonedTaskResult?.getStepResult(nextStep.identifier) == null
+            hasBranching = clonedTaskResult?.getStepResult(nextStep.identifier) == null && isGFitStep(nextStep).not()
 
 
             if (hasBranching) {
@@ -241,6 +241,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     @VisibleForTesting
     fun isReviewStep(step: Step) = step::class.java.simpleName.contains("RSReviewStep", true)
     private fun isCompletionStep(step: Step) = step::class.java.simpleName.contains("RSCompletionStep", true)
+    private fun isGFitStep(step: Step) = step::class.java.simpleName.contains("RSGoogleFitPermissionsStep", true)
 
     companion object {
         const val TAG = "TaskViewModel"
@@ -357,7 +358,9 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
     @VisibleForTesting
     fun checkIfCurrentStepIsBranchDecisionStep(): Boolean {
         val nextStep = task.getStepAfterStep(currentStep, currentTaskResult)
-        return currentTaskResult.getStepResult(nextStep.identifier) == null && !isReviewStep(nextStep)
+        return currentTaskResult.getStepResult(nextStep.identifier) == null
+                && isReviewStep(nextStep).not()
+                && isGFitStep(nextStep).not()
     }
 
     fun revertToOriginalStepResult(originalStepResult: StepResult<*>) {


### PR DESCRIPTION
### Objective
- Fixed PAT-1700: Fixed editing a step that is before `RSGoogleFitPermissionsStep`

### Why
The `RSGoogleFitPermissionsStep` has no result, so when we were checking if there are any branches for a task, we were checking if the next step result is null, and in case of GFit, it is always null. so the code assumed that this task has branches, even when it didn't.

### How To Test
**Context information**
-  Environment: QA
-  Org: Hybridstudy
-  Study: QA-Regression
-  User: angela+q33@medable.com / qpal1010
-  Task: https://app.qa.medable.com/hybridstudy/axon/study/5c76bc486ce0200100f8e68f/task/5c76bc4b6ce0200100f8e7e9

**Steps**
1.  Launch Flask
2.  Login with valid credentials
3.  Start task T00 - All Step Types Survey- do not modify PAT-1700
4.  Reach the review step
5.  Select Edit next to Form step
6.  Edit any sub-step inside the form, click Save and confirm

**Actual:** user is redirected to next step(HK Permissions)
**Expected:** user should return to Review step with form step updated.

### Branches
- PAT: development
- Axon: development
- RS: bug/PAT-1700_edit_step_before_gfit
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PAT-1700

Closes PAT-1700