### PR TITLE
PAT-1727 : Update strings according to user selected locale

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/TextQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/TextQuestionBody.java
@@ -15,6 +15,7 @@ import org.researchstack.backbone.answerformat.TextAnswerFormat;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.QuestionStep;
 import org.researchstack.backbone.step.Step;
+import org.researchstack.backbone.utils.LocaleUtils;
 import org.researchstack.backbone.utils.TextUtils;
 import org.researchstack.backbone.utils.ViewUtils;
 
@@ -43,7 +44,7 @@ public class TextQuestionBody implements StepBody {
         if (step.getPlaceholder() != null) {
             editText.setHint(step.getPlaceholder());
         } else {
-            editText.setHint(R.string.rsb_hint_step_body_text);
+            editText.setHint(LocaleUtils.getLocalizedString(inflater.getContext(),R.string.rsb_hint_step_body_text));
         }
 
         TextView title = body.findViewById(R.id.label);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
@@ -19,6 +19,7 @@ import org.researchstack.backbone.step.ConsentDocumentStep;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.ui.callbacks.StepCallbacks;
 import org.researchstack.backbone.ui.views.SubmitBar;
+import org.researchstack.backbone.utils.LocaleUtils;
 
 /**
  * Implement saved state for the following objects:
@@ -123,6 +124,8 @@ public class ConsentDocumentStepLayout extends LinearLayout implements StepLayou
                 }));
                 submitBar.setNegativeTitleColor(step.getPrimaryColor());
                 submitBar.setNegativeAction(actionView -> disagreeConsent());
+                submitBar.setNegativeTitle(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_disagree));
+                submitBar.setPositiveTitle(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_agree));
             }
         });
 
@@ -137,14 +140,14 @@ public class ConsentDocumentStepLayout extends LinearLayout implements StepLayou
 
     private void showDialog(MaterialDialog.SingleButtonCallback positiveAction) {
         new MaterialDialog.Builder(getContext())
-                .title(R.string.rsb_consent_review_alert_title)
+                .title(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_consent_review_alert_title))
                 .content(confirmationDialogBody)
                 .theme(Theme.LIGHT)
                 .cancelable(false)
                 .positiveColor(step.getColorSecondary())
                 .negativeColor(step.getPrimaryColor())
-                .negativeText(R.string.rsb_consent_review_cancel)
-                .positiveText(R.string.rsb_agree)
+                .negativeText(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_consent_review_cancel))
+                .positiveText(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_agree))
                 .onPositive(positiveAction)
                 .show();
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -105,6 +105,7 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
 
         final AppCompatTextView clear = (AppCompatTextView) findViewById(R.id.layout_consent_review_signature_clear);
         clear.setTextColor(step.getPrimaryColor());
+        clear.setText(LocaleUtils.getLocalizedString(getContext(), R.string.rsb_consent_signature_clear));
 
         signatureView = (SignatureView) findViewById(R.id.layout_consent_review_signature);
         signatureView.setCallbacks(new SignatureCallbacks() {
@@ -138,7 +139,8 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
         final SubmitBar submitBar = (SubmitBar) findViewById(R.id.submit_bar);
         submitBar.getNegativeActionView().setVisibility(View.GONE);
         submitBar.setPositiveTitleColor(step.getColorSecondary());
-        submitBar.setPositiveTitle(R.string.rsb_done);
+        submitBar.setPositiveTitle(LocaleUtils.getLocalizedString(getContext(),
+                R.string.rsb_done));
         submitBar.setPositiveAction(new OnClickListener()
         {
             @Override
@@ -149,7 +151,8 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
                     callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, step, result);
                     submitBar.clearActions();
                 } else {
-                    Toast.makeText(getContext(), R.string.rsb_error_invalid_signature, Toast.LENGTH_SHORT).show();
+                    Toast.makeText(getContext(), LocaleUtils.getLocalizedString(getContext(),
+                            R.string.rsb_error_invalid_signature), Toast.LENGTH_SHORT).show();
                 }
             }
         });

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -112,7 +112,7 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
 
             // Set Next / Skip
             final SubmitBar submitBar = (SubmitBar) findViewById(R.id.rsb_submit_bar);
-            submitBar.setPositiveTitle(getContext().getString(R.string.rsb_next));
+            submitBar.setPositiveTitle(LocaleUtils.getLocalizedString(getContext(), R.string.rsb_next));
             submitBar.setPositiveAction(view -> {
                 callbacks.onSaveStep(StepCallbacks.ACTION_NEXT,
                         step,

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -27,6 +27,7 @@ import org.researchstack.backbone.ui.step.body.FormBody;
 import org.researchstack.backbone.ui.step.body.StepBody;
 import org.researchstack.backbone.ui.views.FixedSubmitBarLayout;
 import org.researchstack.backbone.ui.views.SubmitBar;
+import org.researchstack.backbone.utils.LocaleUtils;
 import org.researchstack.backbone.utils.LogExt;
 import org.researchstack.backbone.utils.TextUtils;
 
@@ -151,10 +152,6 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         initStepBody();
     }
 
-    public void setPositiveText(String text) {
-        submitBar.setPositiveTitle(text);
-    }
-
     @Override
     public void isEditView(boolean isEditView) {
         isEditViewVisible = isEditView;
@@ -208,7 +205,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
             }
 
             if (questionStep.isOptional()) {
-                submitBar.setNegativeTitle(R.string.rsb_step_skip);
+                submitBar.setNegativeTitle(LocaleUtils.getLocalizedString(getContext(), R.string.rsb_step_skip));
                 submitBar.setNegativeAction(v -> onSkipClicked());
             } else {
                 submitBar.getNegativeActionView().setVisibility(View.GONE);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -35,6 +35,7 @@ import org.researchstack.backbone.ui.permissions.PermissionResult
 import org.researchstack.backbone.ui.step.fragments.BaseStepFragment
 import org.researchstack.backbone.ui.step.layout.StepLayout
 import org.researchstack.backbone.ui.step.layout.SurveyStepLayout
+import org.researchstack.backbone.utils.LocaleUtils
 import org.researchstack.backbone.utils.ViewUtils
 
 open class TaskActivity : AppCompatActivity(), PermissionMediator {
@@ -146,6 +147,7 @@ open class TaskActivity : AppCompatActivity(), PermissionMediator {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.rsb_activity_view_task_menu, menu)
         actionBarCancelMenuItem = menu.findItem(R.id.rsb_action_cancel)
+        actionBarCancelMenuItem?.title = LocaleUtils.getLocalizedString(this, R.string.rsb_cancel)
         return true
     }
 
@@ -368,13 +370,13 @@ open class TaskActivity : AppCompatActivity(), PermissionMediator {
                                 onPositive: () -> (Unit)) {
         MaterialDialog.Builder(this)
                 .cancelable(false)
-                .title(title)
-                .content(content)
+                .title(LocaleUtils.getLocalizedString(this, title))
+                .content(LocaleUtils.getLocalizedString(this, content))
                 .theme(Theme.LIGHT)
                 .positiveColor(viewModel.colorPrimary)
                 .negativeColor(viewModel.colorPrimary)
-                .negativeText(negativeText)
-                .positiveText(positiveText)
+                .negativeText(LocaleUtils.getLocalizedString(this, negativeText))
+                .positiveText(LocaleUtils.getLocalizedString(this, positiveText))
                 .onPositive { _, _ -> onPositive() }
                 .onNegative { dialog, _ -> onNegative(dialog) }
                 .show()

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/SignatureView.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/SignatureView.java
@@ -21,6 +21,7 @@ import android.view.View;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ui.callbacks.SignatureCallbacks;
+import org.researchstack.backbone.utils.LocaleUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +90,7 @@ public class SignatureView extends View {
         int signatureStroke = a.getDimensionPixelSize(R.styleable.SignatureView_signatureStrokeSize,
                 defSignatureStroke);
 
-        hintText = a.getString(R.styleable.SignatureView_hintText);
+        hintText = LocaleUtils.getLocalizedString(getContext(), R.string.rsb_consent_signature_placeholder);
 
         hintTextColor = a.getColor(R.styleable.SignatureView_hintTextColor, Color.LTGRAY);
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 
 
 import org.researchstack.backbone.R;
+import org.researchstack.backbone.utils.LocaleUtils;
 
 public class SubmitBar extends LinearLayout {
     private TextView positiveView;
@@ -43,10 +44,11 @@ public class SubmitBar extends LinearLayout {
         setBackground(a.getDrawable(R.styleable.SubmitBar_android_background));
 
         positiveView = (TextView) findViewById(R.id.bar_submit_postitive);
-        positiveView.setText(a.getString(R.styleable.SubmitBar_positiveActionTitle));
+        positiveView.setText(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_next));
 
         negativeView = (TextView) findViewById(R.id.bar_submit_negative);
-        negativeView.setText(a.getString(R.styleable.SubmitBar_negativeActionTitle));
+        positiveView.setText(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_step_skip));
+
 
         editSaveView = (TextView) findViewById(R.id.bar_submit_edit_save);
         editCancelView = (TextView) findViewById(R.id.bar_submit_edit_cancel);


### PR DESCRIPTION
### Description 👍
The goal of this MR is to fix the button and some view labels string are not displayed in the preferred locale

### Branches
PAT: rc/flask-4.10.0
Axon: bug/PAT-1727_update_string_in_buttons
RS: bug/PAT-1727_update_string_in_buttons
Cortex: rc/flask-4.10.0


### Credentials :
env : qa
org : hybridstudy
study : Multi-language Study


### How to test :

### SCENARIO 1

- Launch patient app with a non supported locale (Arabic :P)
- Set the study of the preconditions
- Set Ukrainian....etc as preferred locale
- Reach the welcome screen
- Press join study
- Select a consent task
- Reach the first and last name screen
- Observe all the strings, The buttons and all of the fields are being displayed in preferred locale





