### PR TITLE
PATAND-19: Added secure flag to TaskActivity

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/ReviewStepFullScreenImageActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/ReviewStepFullScreenImageActivity.kt
@@ -5,11 +5,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import kotlinx.android.synthetic.main.rsb_activity_full_screen_image.*
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
+import org.researchstack.backbone.BuildConfig
 import org.researchstack.backbone.R
 import org.researchstack.backbone.step.Step
 import org.researchstack.backbone.ui.step.fragments.ReviewStepFragment
@@ -32,6 +34,12 @@ class ReviewStepFullScreenImageActivity : AppCompatActivity(), View.OnClickListe
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (BuildConfig.USE_SECURE_FLAG) {
+            window.setFlags(
+                    WindowManager.LayoutParams.FLAG_SECURE,
+                    WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
         setContentView(R.layout.rsb_activity_full_screen_image)
 
         initCallbacks()

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -48,6 +48,7 @@ open class TaskActivity : AppCompatActivity(), PermissionMediator {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
         setResult(Activity.RESULT_CANCELED)
         setContentView(R.layout.rsb_activity_task)
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -26,6 +26,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.Theme
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
+import org.researchstack.backbone.BuildConfig
 import org.researchstack.backbone.R
 import org.researchstack.backbone.step.Step
 import org.researchstack.backbone.task.Task
@@ -48,7 +49,12 @@ open class TaskActivity : AppCompatActivity(), PermissionMediator {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+        if (BuildConfig.USE_SECURE_FLAG) {
+            window.setFlags(
+                    WindowManager.LayoutParams.FLAG_SECURE,
+                    WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
         setResult(Activity.RESULT_CANCELED)
         setContentView(R.layout.rsb_activity_task)
 


### PR DESCRIPTION
### Objective
- Fixed PATAND-19: Added secure flag to TaskActivity to prevent taking screenshot for the android task manager

### How To Test
**Context information**
-  Environment: QA
-  Org: Hybridstudy
-  Study: QA-Regression
-  User: angela+q33@medable.com / qpal1010

**Location**
The issue occurs when the user is currently inside any task of the app.

**Bug description**
A blank screen is not shown when the user is within a task and moves the app into the background, like using the Android's Task Manager.

**Steps:**
1.  Launch PAT using the credentials above
2.  Select any valid task
3.  Put the app in the background and open Android's task manager.

**Actual Result:** The preview of the app is displayed, including the current step data.

**Expected Result:** The app's preview should show a blank image, without any study or personal data.

### Branches
- PAT: development
- Axon: development
- RS: bug/PATAND-19_Show_blank_screen_in_TaskManager
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PATAND-19

Closes PATAND-19