### PR TITLE
PATAND-52 : Make sure Task loads preferred locale String

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -47,6 +47,10 @@ open class TaskActivity : AppCompatActivity(), PermissionMediator {
     private var stepPermissionListener: PermissionListener? = null
     private var actionBarCancelMenuItem: MenuItem? = null
 
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(LocaleUtils.wrapLocaleContext(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (BuildConfig.USE_SECURE_FLAG) {

--- a/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
+++ b/backbone/src/main/java/org/researchstack/backbone/utils/LocaleUtils.java
@@ -14,7 +14,12 @@ public class LocaleUtils {
     public static final String LOCALE_PREFERENCES = "LocalePreferences";
     public static final String PREFERRED_LOCALE_FIELD = "PreferredLocale";
 
-    public static ContextWrapper wrapLocaleContext(Context context, Locale locale) {
+    public static ContextWrapper wrapLocaleContext(Context context) {
+        String preferredLocale = getPreferredLocale(context);
+        if (preferredLocale == null){
+            return new ContextWrapper(context);
+        }
+        Locale locale = getLocaleFromString(preferredLocale);
         Configuration config = context.getResources().getConfiguration();
         Locale.setDefault(locale);
         config.setLocale(locale);


### PR DESCRIPTION
**Description 👍**
The goal of this MR is to fix the button and some view labels string, date picker dialogs buttons are not displayed in the preferred locale 

**Branches**
PAT: development 
Axon: bug/PATAND-52_update_locale 
RS: bug/PATAND-52_update_locale 
Cortex: development

**Credentials :**
env : qa
org : hybridstudy
study : Multi-language Study

How to test :
**SCENARIO 1**
Launch pat from scratch 
Set Japanese ....etc as preferred locale
Press join study
Do all the tasks
Observe all the strings, The buttons and all of the fields are being displayed in preferred locale

**SCENARIO 2**
Launch pat  ( with your account )
Put your username/password
Set Italiano ....etc as preferred locale
Do all the tasks
Observe all the strings, The buttons and all of the fields are being displayed in preferred locale


** Please Observe strings in date-time dialogs, auto complete steps, permission buttons etc
