### PR TITLE
PATAND-42: Handle And Report TZ and Locale Changes

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/step/ConsentVisualStep.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/ConsentVisualStep.java
@@ -3,7 +3,6 @@ package org.researchstack.backbone.step;
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.model.ConsentSection;
 import org.researchstack.backbone.ui.step.layout.ConsentVisualStepLayout;
-import org.researchstack.backbone.utils.LocaleUtils;
 
 /**
  * The {@link ConsentVisualStep} class represents a step in the visual consent sequence.

--- a/backbone/src/main/java/org/researchstack/backbone/task/OrderedTask.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/OrderedTask.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.result.TaskResult;
 import org.researchstack.backbone.step.Step;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 import org.researchstack.backbone.utils.TextUtils;
 
 import java.io.Serializable;
@@ -136,7 +136,7 @@ public class OrderedTask extends Task implements Serializable {
                    }
                 }
             }
-            title = LocaleUtils.getLocalizedString(context, R.string.rsb_format_step_title,
+            title = LocalizationUtils.getLocalizedString(context, R.string.rsb_format_step_title,
                     currentIndexWithoutHidden,
                     maxIndexWithoutHidden);
         }

--- a/backbone/src/main/java/org/researchstack/backbone/task/Task.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/Task.java
@@ -6,7 +6,7 @@ import androidx.annotation.NonNull;
 
 import org.researchstack.backbone.result.TaskResult;
 import org.researchstack.backbone.step.Step;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 
 import java.io.Serializable;
 import java.util.List;
@@ -85,7 +85,7 @@ public abstract class Task implements Serializable {
      * @return the title to display
      */
     public String getTitleForStep(Context context, Step step) {
-        return step.getStepTitle() != 0 ? LocaleUtils.getLocalizedString(context, step.getStepTitle()) : "";
+        return step.getStepTitle() != 0 ? LocalizationUtils.getLocalizedString(context, step.getStepTitle()) : "";
     }
 
     /**

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
@@ -19,7 +19,7 @@ import org.researchstack.backbone.task.Task
 import org.researchstack.backbone.ui.step.layout.ConsentSignatureStepLayout.KEY_SIGNATURE
 import org.researchstack.backbone.ui.task.TaskActivity
 import org.researchstack.backbone.ui.task.TaskViewModel
-import org.researchstack.backbone.utils.LocaleUtils
+import org.researchstack.backbone.utils.LocalizationUtils
 import org.researchstack.backbone.utils.RSHTMLPDFWriter
 import java.text.DateFormat
 import java.util.*
@@ -87,15 +87,18 @@ class ConsentTaskActivity : TaskActivity() {
     override fun close(completed: Boolean) {
         // you can also set title / message
         savingConsentDialog = AlertDialog.Builder(this).setCancelable(false)
-                .setTitle(LocaleUtils.getLocalizedString(this, R.string.rsb_saving_consent))
-                .setMessage(LocaleUtils.getLocalizedString(this, R.string.rsb_please_wait)).create()
+                .setTitle(
+                        LocalizationUtils.getLocalizedString(this, R.string.rsb_saving_consent))
+                .setMessage(
+                        LocalizationUtils.getLocalizedString(this, R.string.rsb_please_wait)).create()
 
         savingConsentDialog?.show()
 
         val consentAssetsFolder = intent.getStringExtra(EXTRA_ASSETS_FOLDER)
-        val role = LocaleUtils.getLocalizedString(this, R.string.rsb_consent_role)
+        val role = LocalizationUtils.getLocalizedString(this, R.string.rsb_consent_role)
         val df = DateFormat.getDateInstance(DateFormat.MEDIUM,
-                LocaleUtils.getLocaleFromString(LocaleUtils.getPreferredLocale(this)))
+                LocalizationUtils.getLocaleFromString(
+                        LocalizationUtils.getPreferredLocale(this)))
         consentHtml += getSignatureHtmlContent(getFormalName(firstName, lastName), role, signatureBase64,
                 df.format(Date()))
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/BodyAnswer.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/BodyAnswer.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import androidx.annotation.StringRes;
 
 import org.researchstack.backbone.R;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 
 public class BodyAnswer {
     public static final BodyAnswer VALID = new BodyAnswer(true, 0);
@@ -50,9 +50,9 @@ public class BodyAnswer {
         if (reasonStr != null && !reasonStr.isEmpty()) {
             return reasonStr;
         } else if (getParams().length == 0) {
-            return LocaleUtils.getLocalizedString(context, getReason());
+            return LocalizationUtils.getLocalizedString(context, getReason());
         } else {
-            return LocaleUtils.getLocalizedString(context, getReason(), (Object[]) getParams());
+            return LocalizationUtils.getLocalizedString(context, getReason(), (Object[]) getParams());
         }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DecimalQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DecimalQuestionBody.java
@@ -15,7 +15,7 @@ import org.researchstack.backbone.answerformat.DecimalAnswerFormat;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.QuestionStep;
 import org.researchstack.backbone.step.Step;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 import org.researchstack.backbone.utils.TextUtils;
 import org.researchstack.backbone.utils.ViewUtils;
 
@@ -90,9 +90,9 @@ public class DecimalQuestionBody implements StepBody {
         if (step.getPlaceholder() != null) {
             editText.setHint(step.getPlaceholder());
         } else if (maxValue == Integer.MAX_VALUE) {
-            editText.setHint(LocaleUtils.getLocalizedString(context, R.string.rsb_hint_step_body_int_no_max));
+            editText.setHint(LocalizationUtils.getLocalizedString(context, R.string.rsb_hint_step_body_int_no_max));
         } else {
-            editText.setHint(LocaleUtils.getLocalizedString(context, R.string.rsb_hint_step_body_dec,
+            editText.setHint(LocalizationUtils.getLocalizedString(context, R.string.rsb_hint_step_body_dec,
                     minValue,
                     maxValue));
         }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/IntegerQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/IntegerQuestionBody.java
@@ -15,7 +15,7 @@ import org.researchstack.backbone.answerformat.IntegerAnswerFormat;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.QuestionStep;
 import org.researchstack.backbone.step.Step;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 import org.researchstack.backbone.utils.TextUtils;
 import org.researchstack.backbone.utils.ViewUtils;
 
@@ -90,9 +90,9 @@ public class IntegerQuestionBody implements StepBody {
         if (step.getPlaceholder() != null) {
             editText.setHint(step.getPlaceholder());
         } else if (maxValue == Integer.MAX_VALUE) {
-            editText.setHint(LocaleUtils.getLocalizedString(context, R.string.rsb_hint_step_body_int_no_max));
+            editText.setHint(LocalizationUtils.getLocalizedString(context, R.string.rsb_hint_step_body_int_no_max));
         } else {
-            editText.setHint(LocaleUtils.getLocalizedString(context, R.string.rsb_hint_step_body_int,
+            editText.setHint(LocalizationUtils.getLocalizedString(context, R.string.rsb_hint_step_body_int,
                     minValue,
                     maxValue));
         }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/TextQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/TextQuestionBody.java
@@ -15,7 +15,7 @@ import org.researchstack.backbone.answerformat.TextAnswerFormat;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.QuestionStep;
 import org.researchstack.backbone.step.Step;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 import org.researchstack.backbone.utils.TextUtils;
 import org.researchstack.backbone.utils.ViewUtils;
 
@@ -44,7 +44,7 @@ public class TextQuestionBody implements StepBody {
         if (step.getPlaceholder() != null) {
             editText.setHint(step.getPlaceholder());
         } else {
-            editText.setHint(LocaleUtils.getLocalizedString(inflater.getContext(),R.string.rsb_hint_step_body_text));
+            editText.setHint(LocalizationUtils.getLocalizedString(inflater.getContext(),R.string.rsb_hint_step_body_text));
         }
 
         TextView title = body.findViewById(R.id.label);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
@@ -1,7 +1,6 @@
 package org.researchstack.backbone.ui.step.layout;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -9,7 +8,6 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.LinearLayout;
 
-import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.Theme;
 
@@ -19,7 +17,7 @@ import org.researchstack.backbone.step.ConsentDocumentStep;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.ui.callbacks.StepCallbacks;
 import org.researchstack.backbone.ui.views.SubmitBar;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 
 /**
  * Implement saved state for the following objects:
@@ -124,8 +122,8 @@ public class ConsentDocumentStepLayout extends LinearLayout implements StepLayou
                 }));
                 submitBar.setNegativeTitleColor(step.getPrimaryColor());
                 submitBar.setNegativeAction(actionView -> disagreeConsent());
-                submitBar.setNegativeTitle(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_disagree));
-                submitBar.setPositiveTitle(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_agree));
+                submitBar.setNegativeTitle(LocalizationUtils.getLocalizedString(getContext(),R.string.rsb_disagree));
+                submitBar.setPositiveTitle(LocalizationUtils.getLocalizedString(getContext(),R.string.rsb_agree));
             }
         });
 
@@ -140,14 +138,14 @@ public class ConsentDocumentStepLayout extends LinearLayout implements StepLayou
 
     private void showDialog(MaterialDialog.SingleButtonCallback positiveAction) {
         new MaterialDialog.Builder(getContext())
-                .title(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_consent_review_alert_title))
+                .title(LocalizationUtils.getLocalizedString(getContext(),R.string.rsb_consent_review_alert_title))
                 .content(confirmationDialogBody)
                 .theme(Theme.LIGHT)
                 .cancelable(false)
                 .positiveColor(step.getColorSecondary())
                 .negativeColor(step.getPrimaryColor())
-                .negativeText(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_consent_review_cancel))
-                .positiveText(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_agree))
+                .negativeText(LocalizationUtils.getLocalizedString(getContext(),R.string.rsb_consent_review_cancel))
+                .positiveText(LocalizationUtils.getLocalizedString(getContext(),R.string.rsb_agree))
                 .onPositive(positiveAction)
                 .show();
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -20,7 +20,7 @@ import org.researchstack.backbone.ui.callbacks.StepCallbacks;
 import org.researchstack.backbone.ui.views.SignatureView;
 import org.researchstack.backbone.ui.views.SubmitBar;
 import org.researchstack.backbone.utils.FormatHelper;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 import org.researchstack.backbone.utils.TextUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -105,7 +105,7 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
 
         final AppCompatTextView clear = (AppCompatTextView) findViewById(R.id.layout_consent_review_signature_clear);
         clear.setTextColor(step.getPrimaryColor());
-        clear.setText(LocaleUtils.getLocalizedString(getContext(), R.string.rsb_consent_signature_clear));
+        clear.setText(LocalizationUtils.getLocalizedString(getContext(), R.string.rsb_consent_signature_clear));
 
         signatureView = (SignatureView) findViewById(R.id.layout_consent_review_signature);
         signatureView.setCallbacks(new SignatureCallbacks() {
@@ -139,7 +139,7 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
         final SubmitBar submitBar = (SubmitBar) findViewById(R.id.submit_bar);
         submitBar.getNegativeActionView().setVisibility(View.GONE);
         submitBar.setPositiveTitleColor(step.getColorSecondary());
-        submitBar.setPositiveTitle(LocaleUtils.getLocalizedString(getContext(),
+        submitBar.setPositiveTitle(LocalizationUtils.getLocalizedString(getContext(),
                 R.string.rsb_done));
         submitBar.setPositiveAction(new OnClickListener()
         {
@@ -151,7 +151,7 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
                     callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, step, result);
                     submitBar.clearActions();
                 } else {
-                    Toast.makeText(getContext(), LocaleUtils.getLocalizedString(getContext(),
+                    Toast.makeText(getContext(), LocalizationUtils.getLocalizedString(getContext(),
                             R.string.rsb_error_invalid_signature), Toast.LENGTH_SHORT).show();
                 }
             }
@@ -162,7 +162,7 @@ public class ConsentSignatureStepLayout extends RelativeLayout implements StepLa
 
         String format = ((ConsentSignatureStep) step).getSignatureDateFormat();
         DateFormat signatureDateFormat = !TextUtils.isEmpty(format)
-                ? DateFormat.getDateInstance(DateFormat.MEDIUM, LocaleUtils.getLocaleFromString(LocaleUtils.getPreferredLocale(getContext())))
+                ? DateFormat.getDateInstance(DateFormat.MEDIUM, LocalizationUtils.getLocaleFromString(LocalizationUtils.getPreferredLocale(getContext())))
                 : FormatHelper.getSignatureFormat();
         String formattedSignDate = signatureDateFormat.format(new Date());
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
@@ -18,7 +18,7 @@ import org.researchstack.backbone.ui.ViewWebDocumentActivity;
 import org.researchstack.backbone.ui.callbacks.StepCallbacks;
 import org.researchstack.backbone.ui.views.FixedSubmitBarLayout;
 import org.researchstack.backbone.ui.views.SubmitBar;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 import org.researchstack.backbone.utils.ResUtils;
 import org.researchstack.backbone.utils.TextUtils;
 
@@ -138,7 +138,7 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
         // Set Title
         TextView titleView = (TextView) findViewById(R.id.title);
         if (TextUtils.isEmpty(data.getTitle())) {
-            titleView.setText(LocaleUtils.getLocalizedString(getContext(), data.getType().getTitleResId()));
+            titleView.setText(LocalizationUtils.getLocalizedString(getContext(), data.getType().getTitleResId()));
         } else {
             titleView.setText(data.getTitle());
         }
@@ -159,11 +159,11 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
             }
             else
             {
-                moreInfoView.setText(LocaleUtils.getLocalizedString(moreInfoView.getContext(), data.getType().getMoreInfoResId()));
+                moreInfoView.setText(LocalizationUtils.getLocalizedString(moreInfoView.getContext(), data.getType().getMoreInfoResId()));
             }
 
             moreInfoView.setOnClickListener(view -> {
-                String webTitle = LocaleUtils.getLocalizedString(moreInfoView.getContext(), R.string.rsb_consent_section_more_info);
+                String webTitle = LocalizationUtils.getLocalizedString(moreInfoView.getContext(), R.string.rsb_consent_section_more_info);
                 URL contentUrl = data.getContentUrl();
                 Intent webDoc;
                 if(contentUrl != null)
@@ -185,7 +185,7 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
         }
 
         final SubmitBar submitBar = findViewById(R.id.rsb_submit_bar);
-        submitBar.setPositiveTitle(LocaleUtils.getLocalizedString(getContext(), step.getNextButtonString()));
+        submitBar.setPositiveTitle(LocalizationUtils.getLocalizedString(getContext(), step.getNextButtonString()));
         submitBar.setNegativeTitleColor(colorPrimary);
         submitBar.setPositiveTitleColor(colorSecondary);
         submitBar.setPositiveAction(view -> {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -15,7 +15,7 @@ import org.researchstack.backbone.ui.ViewWebDocumentActivity;
 import org.researchstack.backbone.ui.callbacks.StepCallbacks;
 import org.researchstack.backbone.ui.views.FixedSubmitBarLayout;
 import org.researchstack.backbone.ui.views.SubmitBar;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 import org.researchstack.backbone.utils.TextUtils;
 
 public class InstructionStepLayout extends FixedSubmitBarLayout implements StepLayout {
@@ -112,7 +112,7 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
 
             // Set Next / Skip
             final SubmitBar submitBar = (SubmitBar) findViewById(R.id.rsb_submit_bar);
-            submitBar.setPositiveTitle(LocaleUtils.getLocalizedString(getContext(), R.string.rsb_next));
+            submitBar.setPositiveTitle(LocalizationUtils.getLocalizedString(getContext(), R.string.rsb_next));
             submitBar.setPositiveAction(view -> {
                 callbacks.onSaveStep(StepCallbacks.ACTION_NEXT,
                         step,
@@ -121,7 +121,7 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
             });
 
             if (step.isOptional()) {
-                submitBar.setNegativeTitle(LocaleUtils.getLocalizedString(submitBar.getContext(), R.string.rsb_step_skip));
+                submitBar.setNegativeTitle(LocalizationUtils.getLocalizedString(submitBar.getContext(), R.string.rsb_step_skip));
                 submitBar.setNegativeAction(view -> {
                     callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, step, null);
                     submitBar.clearActions();

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -27,7 +27,7 @@ import org.researchstack.backbone.ui.step.body.FormBody;
 import org.researchstack.backbone.ui.step.body.StepBody;
 import org.researchstack.backbone.ui.views.FixedSubmitBarLayout;
 import org.researchstack.backbone.ui.views.SubmitBar;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 import org.researchstack.backbone.utils.LogExt;
 import org.researchstack.backbone.utils.TextUtils;
 
@@ -205,7 +205,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
             }
 
             if (questionStep.isOptional()) {
-                submitBar.setNegativeTitle(LocaleUtils.getLocalizedString(getContext(), R.string.rsb_step_skip));
+                submitBar.setNegativeTitle(LocalizationUtils.getLocalizedString(getContext(), R.string.rsb_step_skip));
                 submitBar.setNegativeAction(v -> onSkipClicked());
             } else {
                 submitBar.getNegativeActionView().setVisibility(View.GONE);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskActivity.kt
@@ -36,7 +36,7 @@ import org.researchstack.backbone.ui.permissions.PermissionResult
 import org.researchstack.backbone.ui.step.fragments.BaseStepFragment
 import org.researchstack.backbone.ui.step.layout.StepLayout
 import org.researchstack.backbone.ui.step.layout.SurveyStepLayout
-import org.researchstack.backbone.utils.LocaleUtils
+import org.researchstack.backbone.utils.LocalizationUtils
 import org.researchstack.backbone.utils.ViewUtils
 
 open class TaskActivity : AppCompatActivity(), PermissionMediator {
@@ -48,7 +48,7 @@ open class TaskActivity : AppCompatActivity(), PermissionMediator {
     private var actionBarCancelMenuItem: MenuItem? = null
 
     override fun attachBaseContext(newBase: Context?) {
-        super.attachBaseContext(LocaleUtils.wrapLocaleContext(newBase))
+        super.attachBaseContext(LocalizationUtils.wrapLocaleContext(newBase))
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -158,7 +158,7 @@ open class TaskActivity : AppCompatActivity(), PermissionMediator {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.rsb_activity_view_task_menu, menu)
         actionBarCancelMenuItem = menu.findItem(R.id.rsb_action_cancel)
-        actionBarCancelMenuItem?.title = LocaleUtils.getLocalizedString(this, R.string.rsb_cancel)
+        actionBarCancelMenuItem?.title = LocalizationUtils.getLocalizedString(this, R.string.rsb_cancel)
         return true
     }
 
@@ -381,13 +381,13 @@ open class TaskActivity : AppCompatActivity(), PermissionMediator {
                                 onPositive: () -> (Unit)) {
         MaterialDialog.Builder(this)
                 .cancelable(false)
-                .title(LocaleUtils.getLocalizedString(this, title))
-                .content(LocaleUtils.getLocalizedString(this, content))
+                .title(LocalizationUtils.getLocalizedString(this, title))
+                .content(LocalizationUtils.getLocalizedString(this, content))
                 .theme(Theme.LIGHT)
                 .positiveColor(viewModel.colorPrimary)
                 .negativeColor(viewModel.colorPrimary)
-                .negativeText(LocaleUtils.getLocalizedString(this, negativeText))
-                .positiveText(LocaleUtils.getLocalizedString(this, positiveText))
+                .negativeText(LocalizationUtils.getLocalizedString(this, negativeText))
+                .positiveText(LocalizationUtils.getLocalizedString(this, positiveText))
                 .onPositive { _, _ -> onPositive() }
                 .onNegative { dialog, _ -> onNegative(dialog) }
                 .show()

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/SignatureView.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/SignatureView.java
@@ -21,7 +21,7 @@ import android.view.View;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ui.callbacks.SignatureCallbacks;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,7 +90,7 @@ public class SignatureView extends View {
         int signatureStroke = a.getDimensionPixelSize(R.styleable.SignatureView_signatureStrokeSize,
                 defSignatureStroke);
 
-        hintText = LocaleUtils.getLocalizedString(getContext(), R.string.rsb_consent_signature_placeholder);
+        hintText = LocalizationUtils.getLocalizedString(getContext(), R.string.rsb_consent_signature_placeholder);
 
         hintTextColor = a.getColor(R.styleable.SignatureView_hintTextColor, Color.LTGRAY);
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/SubmitBar.java
@@ -12,7 +12,7 @@ import android.widget.TextView;
 
 
 import org.researchstack.backbone.R;
-import org.researchstack.backbone.utils.LocaleUtils;
+import org.researchstack.backbone.utils.LocalizationUtils;
 
 public class SubmitBar extends LinearLayout {
     private TextView positiveView;
@@ -44,10 +44,10 @@ public class SubmitBar extends LinearLayout {
         setBackground(a.getDrawable(R.styleable.SubmitBar_android_background));
 
         positiveView = (TextView) findViewById(R.id.bar_submit_postitive);
-        positiveView.setText(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_next));
+        positiveView.setText(LocalizationUtils.getLocalizedString(getContext(),R.string.rsb_next));
 
         negativeView = (TextView) findViewById(R.id.bar_submit_negative);
-        negativeView.setText(LocaleUtils.getLocalizedString(getContext(),R.string.rsb_step_skip));
+        negativeView.setText(LocalizationUtils.getLocalizedString(getContext(),R.string.rsb_step_skip));
 
         editSaveView = (TextView) findViewById(R.id.bar_submit_edit_save);
         editCancelView = (TextView) findViewById(R.id.bar_submit_edit_cancel);

--- a/backbone/src/main/java/org/researchstack/backbone/utils/LocalizationUtils.java
+++ b/backbone/src/main/java/org/researchstack/backbone/utils/LocalizationUtils.java
@@ -9,10 +9,11 @@ import java.util.Locale;
 
 import static android.content.Context.MODE_PRIVATE;
 
-public class LocaleUtils {
+public class LocalizationUtils {
 
     public static final String LOCALE_PREFERENCES = "LocalePreferences";
     public static final String PREFERRED_LOCALE_FIELD = "PreferredLocale";
+    public static final String TIMEZONE_FIELD = "TimeZone";
 
     public static ContextWrapper wrapLocaleContext(Context context) {
         String preferredLocale = getPreferredLocale(context);
@@ -67,5 +68,17 @@ public class LocaleUtils {
     public static String getPreferredLocale(Context context) {
         SharedPreferences sharedPrefs = context.getSharedPreferences(LOCALE_PREFERENCES, MODE_PRIVATE);
         return sharedPrefs.getString(PREFERRED_LOCALE_FIELD, null);
+    }
+
+    public static void setTimeZone(Context context, String timeZone) {
+        SharedPreferences sharedPrefs = context.getSharedPreferences(LOCALE_PREFERENCES, MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPrefs.edit();
+        editor.putString(TIMEZONE_FIELD, timeZone);
+        editor.apply();
+    }
+
+    public static String getTimeZone(Context context) {
+        SharedPreferences sharedPrefs = context.getSharedPreferences(LOCALE_PREFERENCES, MODE_PRIVATE);
+        return sharedPrefs.getString(TIMEZONE_FIELD, null);
     }
 }


### PR DESCRIPTION
# Objective
- Implement PATAND-42: Handle and report time zone changes

## What changed in this repo?
- Renamed `LocaleUtils` to `LocalizationUtils`
- Added TimeZone setter and getter in LocalizationUtils for storing the TZ in SharedPreferences

# How To Test
For now in order to test this:
  1. Filter the logcat with `LocalizationDelegate`
  2. Debug the `LocalizationDelegateImpl.reportTimeZoneAndLocale()` method to make sure we're sending the correct TZ and locale


## Credentials:
- Environment: QA
- Org: hybridstudy
- Study: Multi-language

## Steps:
### Scenario 1
  1. Open the app using the credentials above
  2. Put it in the background
  3. Change the device's time zone
  4. Bring back the app to the foreground

**Expected:** This should update the TimeZone in SharedPreferences and send it (along with the current locale) to the backend.

### Scenario 2:
  1. Open the app using the credentials above
  2. Join Study

**Expected:** This should send TZ and locale to the backend.


### Scenario 3:
  1. Open the app using the credentials above
  2. Login using an existing account

**Expected:** This should send TZ and locale to the backend.


### Scenario 4:
  1. Open the app using the credentials above
  2. Join Study OR Login using an existing account
  3. Change preferred locale from Profile screen

**Expected:** This should save new locale and send it (along with the current time zone) to the backend.

# Branches
- PAT: task/PATAND-42_Handle_And_Report_TZ_Changes
- Axon: task/PATAND-42_Handle_And_Report_TZ_Changes
- RS: task/PATAND-42_Handle_And_Report_TZ_Changes
- Cortex: task/PATAND-42_Handle_And_Report_TZ_Changes

# Links
- https://jira.devops.medable.com/browse/PATAND-42


Closes PATAND-42