### PR TITLE
PATAND-123: Consent review step view is broken after opening task manager and returning

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/fragments/BaseStepFragment.kt
@@ -1,5 +1,6 @@
 package org.researchstack.backbone.ui.step.fragments
 
+import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -22,9 +23,8 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
 
     protected val viewModel: TaskViewModel by sharedViewModel()
 
-    override fun onResume() {
-        super.onResume()
-
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val currentStep = viewModel.currentStep
         val stepResult = viewModel.currentTaskResult.getStepResult(currentStep?.identifier)
 
@@ -65,7 +65,6 @@ internal open class BaseStepFragment(@LayoutRes contentLayoutId: Int) : Fragment
                 Log.d("BaseStepFragment", "WARNING: Unknown stepView type, cannot initialize layout")
             }
         }
-
     }
 
     private fun setupStepCallbacks(stepView: StepLayout) {


### PR DESCRIPTION
### Objective
- Fixed PATAND-123: Consent review step view is broken after opening task manager and returning
- The problem is the view is rendered at onResume() method, so when you go to the background and back to the app again the view is re-rendered again that's why you see the view is broken
- So my solution is mainly remove rendering the view from onResume() to onViewCreated()

### How To Test
**Credentials:**
- Environment: QA
- Org: hybridstudy
- Study: Multi-language study

**Bug description**
If the user is in the Consent Review section and he opens the task manager and go back to the Consent review, the view of the task is broken displaying a separate block of options as it was a normal step with the options to Skip or Next (which are actually not interactive).

**Steps:**
 .  Fresh launch the Android app
 . Reach Welcome screen and select Join study
 . In the consent task complete every step and reach the Consent review step
 . In the consent review step open the Android task manager and enter the app again from the running applications
Repeat 4 multiple times
**Expected:**
1. The Edit button should appear
2. The user should be able to edit the first task, and the result should change according to the user selection
### Branches
- PAT: fix/PATAND-123_consent_review_step_view
- Axon: fix/PATAND-123_consent_review_step_view
- RS: fix/PATAND-123_consent_review_step_view
- Cortex: development

### Links
- https://jira.devops.medable.com/browse/PATAND-123

Closes PATAND-123