### PR TITLE
Patand 196 : Update Counter Formats in Header on Japanese Screens

### DIFF
--- a/backbone/src/main/res/values-ja-rJP/strings.xml
+++ b/backbone/src/main/res/values-ja-rJP/strings.xml
@@ -56,7 +56,7 @@
     <string name="rsb_disagree">同意しない</string>
     <string name="rsb_agree">同意する</string>
     <string name="rsb_cancel">キャンセル</string>
-    <string name="rsb_format_step_title">ステップ%2$s/%1$s</string>
+    <string name="rsb_format_step_title">ステップ%1$s/%2$s</string>
     <string name="rsb_hours">時</string>
     <string name="rsb_minutes">分</string>
     <string name="rsb_task_cancel_title">アクティビティから退出</string>


### PR DESCRIPTION
Update Counter Formats in Header on Japanese Screens please check the screenshot in this [ticket](https://jira.devops.medable.com/browse/PATAND-196)

### Branches
PAT: development
Axon: development
Cortex: development
RS: bug/PATAND-196

### Credentials
Environment: QA
Org: hybridstudy
Study: ML

### How to test : 
1- lunch PAT
2- login/join study
3- go to profile and choose the Japanese language
4- start any task
Expected result:  the header count should be 1 / 2 NOT 2/1



 