### PR TITLE
PATAND-201: Add time, hour and TZ on the consent pdf

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
@@ -97,7 +97,7 @@ class ConsentTaskActivity : TaskActivity() {
 
         val consentAssetsFolder = intent.getStringExtra(EXTRA_ASSETS_FOLDER)
         val role = LocalizationUtils.getLocalizedString(this, R.string.rsb_consent_role)
-        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z")
+        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.getDefault())
         consentHtml += getSignatureHtmlContent(getFormalName(firstName, lastName), role, signatureBase64,
                 df.format(Date()))
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
@@ -97,7 +97,9 @@ class ConsentTaskActivity : TaskActivity() {
 
         val consentAssetsFolder = intent.getStringExtra(EXTRA_ASSETS_FOLDER)
         val role = LocalizationUtils.getLocalizedString(this, R.string.rsb_consent_role)
-        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.getDefault())
+        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss 'UTC'",
+                LocalizationUtils.getLocaleFromString(LocalizationUtils.getPreferredLocale(this)))
+        df.timeZone = TimeZone.getTimeZone("UTC")
         consentHtml += getSignatureHtmlContent(getFormalName(firstName, lastName), role, signatureBase64,
                 df.format(Date()))
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
@@ -22,6 +22,7 @@ import org.researchstack.backbone.ui.task.TaskViewModel
 import org.researchstack.backbone.utils.LocalizationUtils
 import org.researchstack.backbone.utils.RSHTMLPDFWriter
 import java.text.DateFormat
+import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -96,9 +97,7 @@ class ConsentTaskActivity : TaskActivity() {
 
         val consentAssetsFolder = intent.getStringExtra(EXTRA_ASSETS_FOLDER)
         val role = LocalizationUtils.getLocalizedString(this, R.string.rsb_consent_role)
-        val df = DateFormat.getDateInstance(DateFormat.MEDIUM,
-                LocalizationUtils.getLocaleFromString(
-                        LocalizationUtils.getPreferredLocale(this)))
+        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z")
         consentHtml += getSignatureHtmlContent(getFormalName(firstName, lastName), role, signatureBase64,
                 df.format(Date()))
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
@@ -97,7 +97,7 @@ class ConsentTaskActivity : TaskActivity() {
 
         val consentAssetsFolder = intent.getStringExtra(EXTRA_ASSETS_FOLDER)
         val role = LocalizationUtils.getLocalizedString(this, R.string.rsb_consent_role)
-        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss 'UTC'",
+        val df = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.LONG,
                 LocalizationUtils.getLocaleFromString(LocalizationUtils.getPreferredLocale(this)))
         df.timeZone = TimeZone.getTimeZone("UTC")
         consentHtml += getSignatureHtmlContent(getFormalName(firstName, lastName), role, signatureBase64,

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
@@ -10,11 +10,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.researchstack.backbone.R
 import org.researchstack.backbone.result.StepResult
-import org.researchstack.backbone.step.ConsentDocumentStep
-import org.researchstack.backbone.step.ConsentSignatureStep
-import org.researchstack.backbone.step.FormStep
-import org.researchstack.backbone.step.QuestionStep
-import org.researchstack.backbone.step.Step
+import org.researchstack.backbone.step.*
 import org.researchstack.backbone.task.Task
 import org.researchstack.backbone.ui.step.layout.ConsentSignatureStepLayout.KEY_SIGNATURE
 import org.researchstack.backbone.ui.task.TaskActivity
@@ -22,7 +18,6 @@ import org.researchstack.backbone.ui.task.TaskViewModel
 import org.researchstack.backbone.utils.LocalizationUtils
 import org.researchstack.backbone.utils.RSHTMLPDFWriter
 import java.text.DateFormat
-import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.collections.ArrayList
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
@@ -101,7 +101,7 @@ class ConsentTaskActivity : TaskActivity() {
                 LocalizationUtils.getLocaleFromString(LocalizationUtils.getPreferredLocale(this)))
         df.timeZone = TimeZone.getTimeZone("UTC")
         consentHtml += getSignatureHtmlContent(getFormalName(firstName, lastName), role, signatureBase64,
-                df.format(Date()))
+                df.format(viewModel.taskResult.endDate))
 
         PDFWriteExposer().printPdfFile(this, getCurrentTaskId(), consentHtml!!, consentAssetsFolder) {
             savingConsentDialog?.dismiss()

--- a/backbone/src/test/java/org/researchstack/backbone/ui/ConsentTaskTest.kt
+++ b/backbone/src/test/java/org/researchstack/backbone/ui/ConsentTaskTest.kt
@@ -1,0 +1,2 @@
+package org.researchstack.backbone.ui
+

--- a/backbone/src/test/java/org/researchstack/backbone/ui/ConsentTaskTest.kt
+++ b/backbone/src/test/java/org/researchstack/backbone/ui/ConsentTaskTest.kt
@@ -1,2 +1,0 @@
-package org.researchstack.backbone.ui
-


### PR DESCRIPTION
## Objective
This MR is for adding the time, hour and TZ on the consent pdf.

## Branches
- PAT: development
- Axon: development
- RS: task/PATAND-201_add_time_to_pdf
- Cortex: development

## SCENARIO: 

#### Credentials:
- Environment: Int-Dev
- Org: hybridstudy
- Study: Multi-language study
- User: a public user

#### Steps:
* open flask/ resumed it 
* Start as a public user
* Do the consent task. 
* After the upload, display the PDF
* Expected result: The date display on the bottom right also display the hour, minute and timezone

Close PATAND-201