### PR TITLE
PATAND-189, PATAND-225: Fixing the crash when we disagree the ConsentTask

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ConsentTaskActivity.kt
@@ -95,8 +95,9 @@ class ConsentTaskActivity : TaskActivity() {
         val df = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.LONG,
                 LocalizationUtils.getLocaleFromString(LocalizationUtils.getPreferredLocale(this)))
         df.timeZone = TimeZone.getTimeZone("UTC")
+        val endDate = viewModel.taskResult.endDate ?: Date()
         consentHtml += getSignatureHtmlContent(getFormalName(firstName, lastName), role, signatureBase64,
-                df.format(viewModel.taskResult.endDate))
+                df.format(endDate))
 
         PDFWriteExposer().printPdfFile(this, getCurrentTaskId(), consentHtml!!, consentAssetsFolder) {
             savingConsentDialog?.dismiss()


### PR DESCRIPTION
## Objective
This MR fix a crash occurring when we disagree to a ConsentTask and when we press back on the ConsentTask.

## Branches
- PAT: development
- Axon: development
- RS: task/PATAND-189_fixing_crash_when_disagree
- Cortex: development

## SCENARIO 1: 

#### Credentials:
- Environment: Int-Dev
- Org: hybridstudy
- Study: Multi-language study

#### Steps
* Use a public user then on the consent task disagree on the consent review. 
* **Expected result** : The consent will start again after the upload of the task and no crash will happen

## SCENARIO 2: 

#### Credentials:
- Environment: QA
- Org: hybridstudy
- Study: fede study emtpy
- User: fforciniti+03test@medable.com/qpal1010

#### Steps
* Login then start the only task (docu). Just press back. 
* **Expected result** : No crash and the task will not start automatically again

Close PATAND-189, PATAND-225