### PR TITLE
PATAND-233: Consent Task: The consent task is not uploaded after a timeout.

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/task/TaskViewModel.kt
@@ -22,6 +22,7 @@ import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_TASK
 import org.researchstack.backbone.ui.task.TaskActivity.Companion.EXTRA_TASK_RESULT
 import java.util.Date
 import java.util.Stack
+import java.util.UUID
 import kotlin.properties.Delegates
 
 internal class TaskViewModel(val context: Application, intent: Intent) : AndroidViewModel(context) {
@@ -73,7 +74,7 @@ internal class TaskViewModel(val context: Application, intent: Intent) : Android
 
     init {
         taskResult = intent.extras?.get(EXTRA_TASK_RESULT) as TaskResult?
-                ?: TaskResult(task.identifier).apply { startDate = Date() }
+                ?: TaskResult(UUID.randomUUID().toString()).apply { startDate = Date() }
 
         task.validateParameters()
     }


### PR DESCRIPTION
Fixing task responses not being uploaded after a session timeout.
although the ticket says that this happens with consent tasks, this should happen with any task type once you are logged in and a session timeout is fired

How to test this:

1- on a fresh install, select QA -> hybrid study -> Qa regression
2- Complete Eligibility, consent, and auth tasks
3- Open "Consent A" task (don't complete the task)
4- Wait enough time so that the session times out
5- Complete the consent task
6- Uploading response dialog will be shown, and the you should be redirected to the login screen
7- Login and wait until all the data is loaded
8- Go to the web portal, and check that the task response is there
9- Go to the profile screen, select consent option, and make sure that you see all the consents you completed.


Note: I would recommend to repeat this flow with "Consent A", "Consent B", and some other random task

Branches: <br>
PAT, Axon, RS: bug/PATAND-233
Cortex: development

Closes PATAND-233