### PR TITLE
PATAND-248: Update instruction layout

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -86,7 +86,6 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
 
     private void initializeStep() {
         if (step != null) {
-
             // Set Title
             if (!TextUtils.isEmpty(step.getTitle())) {
                 TextView title = findViewById(R.id.rsb_intruction_title);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -2,7 +2,6 @@ package org.researchstack.backbone.ui.step.layout;
 
 import android.content.Context;
 import android.content.Intent;
-import android.text.Html;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.TextView;
@@ -90,14 +89,14 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
             if (!TextUtils.isEmpty(step.getTitle())) {
                 TextView title = findViewById(R.id.rsb_intruction_title);
                 title.setVisibility(View.VISIBLE);
-                title.setText(HtmlCompat.fromHtml(step.getTitle(),HtmlCompat.FROM_HTML_MODE_COMPACT));
+                title.setText(HtmlCompat.fromHtml(step.getTitle(), HtmlCompat.FROM_HTML_MODE_COMPACT));
             }
 
             // Set Summary
             if (!TextUtils.isEmpty(step.getText())) {
                 TextView summary = findViewById(R.id.rsb_intruction_text);
                 summary.setVisibility(View.VISIBLE);
-                summary.setText(HtmlCompat.fromHtml(step.getText(),HtmlCompat.FROM_HTML_MODE_COMPACT));
+                summary.setText(HtmlCompat.fromHtml(step.getText(), HtmlCompat.FROM_HTML_MODE_COMPACT));
                 summary.setMovementMethod(new TextViewLinkHandler() {
                     @Override
                     public void onLinkClick(String url) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -7,6 +7,8 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.core.text.HtmlCompat;
+
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ResourcePathManager;
 import org.researchstack.backbone.result.StepResult;
@@ -87,16 +89,16 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
 
             // Set Title
             if (!TextUtils.isEmpty(step.getTitle())) {
-                TextView title = (TextView) findViewById(R.id.rsb_intruction_title);
+                TextView title = findViewById(R.id.rsb_intruction_title);
                 title.setVisibility(View.VISIBLE);
-                title.setText(step.getTitle());
+                title.setText(HtmlCompat.fromHtml(step.getTitle(),HtmlCompat.FROM_HTML_MODE_COMPACT));
             }
 
             // Set Summary
             if (!TextUtils.isEmpty(step.getText())) {
-                TextView summary = (TextView) findViewById(R.id.rsb_intruction_text);
+                TextView summary = findViewById(R.id.rsb_intruction_text);
                 summary.setVisibility(View.VISIBLE);
-                summary.setText(Html.fromHtml(step.getText()));
+                summary.setText(HtmlCompat.fromHtml(step.getText(),HtmlCompat.FROM_HTML_MODE_COMPACT));
                 summary.setMovementMethod(new TextViewLinkHandler() {
                     @Override
                     public void onLinkClick(String url) {
@@ -111,7 +113,7 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
             }
 
             // Set Next / Skip
-            final SubmitBar submitBar = (SubmitBar) findViewById(R.id.rsb_submit_bar);
+            final SubmitBar submitBar = findViewById(R.id.rsb_submit_bar);
             submitBar.setPositiveTitle(LocalizationUtils.getLocalizedString(getContext(), R.string.rsb_next));
             submitBar.setPositiveAction(view -> {
                 callbacks.onSaveStep(StepCallbacks.ACTION_NEXT,

--- a/backbone/src/main/res/layout/rsb_step_layout_instruction.xml
+++ b/backbone/src/main/res/layout/rsb_step_layout_instruction.xml
@@ -1,28 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?><!-- Change to RelativeLayout for preview to work -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:filterTouchesWhenObscured="true"
-    android:orientation="vertical">
+    android:filterTouchesWhenObscured="true">
 
     <TextView
         android:id="@+id/rsb_intruction_title"
-        style="@style/Backbone.Survey.Title"
+        style="@style/H5SelectedOnSecondaryHighEmphasisLeft"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:textColor="@color/black_87"
         android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginStart="@dimen/rsb_margin_left"
+        android:layout_marginEnd="@dimen/rsb_margin_right"
+        android:layout_marginTop="@dimen/rsb_margin_top_large"
         tools:text="@string/lorem_name"
         tools:visibility="visible" />
 
     <TextView
         android:id="@+id/rsb_intruction_text"
-        style="@style/Backbone.Survey.Summary"
+        style="@style/TextStyle3"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColorLink="?attr/colorAccent"
+        android:textColor="@color/black_60"
+        android:layout_marginStart="@dimen/rsb_margin_left"
+        android:layout_marginEnd="@dimen/rsb_margin_right"
+        android:layout_marginTop="@dimen/rsb_margin_top_10"
         android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/rsb_intruction_title"
         tools:text="@string/lorem_long"
         tools:visibility="visible" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/backbone/src/main/res/layout/rsb_view_submitbar.xml
+++ b/backbone/src/main/res/layout/rsb_view_submitbar.xml
@@ -17,6 +17,7 @@
         android:layout_height="wrap_content"
         android:padding="20dp"
         android:text="@string/rsb_consent_review_cancel"
+        android:visibility="gone"
         android:textAllCaps="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Objective
Implement the change for the completion step

## Branches
- PAT: development
- Axon: development
- RS: task/PATAND-248_instruction_step
- Cortex: development

## SCENARIO: 

#### Credentials:
- Environment: QA
- Org: hybridstudy
- Study: QA-Regression
- User: matias.battaglia+4@medable.com/qpal1010
- Task: instruction test

#### Steps:
* open flask/ resumed it 
* Login if it's not the case
* Start the right task
Expected: 
* The new UI will fit the new ui (same margin that the other, etc.) There is none zeplin for this one


Close PATAND-248