### PR TITLE
Added the UAT flavor to build.gradle

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -43,16 +43,20 @@ android {
 
     productFlavors {
         def useSecureFlagProd = rootProject.hasProperty("useSecureFlagProd") ? rootProject.useSecureFlagProd : true
+        def useSecureFlagUat = rootProject.hasProperty("useSecureFlagUat") ? rootProject.useSecureFlagUat : false
         def useSecureFlagDev = rootProject.hasProperty("useSecureFlagDev") ? rootProject.useSecureFlagDev : false
 
         prod {
             buildConfigField 'boolean', 'USE_SECURE_FLAG', "$useSecureFlagProd"
         }
 
+        uat {
+            buildConfigField 'boolean', 'USE_SECURE_FLAG', "$useSecureFlagUat"
+        }
+
         dev {
             buildConfigField 'boolean', 'USE_SECURE_FLAG', "$useSecureFlagDev"
         }
-
     }
 
     compileOptions {


### PR DESCRIPTION
- We need to add the UAT flavor to ResearchStack's Backbone build.gradle so that CS projects will compile via CI.

A simple addition:

```
productFlavors  {
        def useSecureFlagProd = rootProject.hasProperty("useSecureFlagProd") ? rootProject.useSecureFlagProd : true
        def useSecureFlagUat = rootProject.hasProperty("useSecureFlagUat") ? rootProject.useSecureFlagUat : false
        def useSecureFlagDev = rootProject.hasProperty("useSecureFlagDev") ? rootProject.useSecureFlagDev : false

        prod {
            buildConfigField 'boolean', 'USE_SECURE_FLAG', "$useSecureFlagProd"
        }

        uat {
            buildConfigField 'boolean', 'USE_SECURE_FLAG', "$useSecureFlagUat"
        }

        dev {
            buildConfigField 'boolean', 'USE_SECURE_FLAG', "$useSecureFlagDev"
        }
    }
```

- https://jira.devops.medable.com/browse/PATAND-323