### PR TITLE
Consent: design of Name insert screen is not correct

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/FormBody.java
@@ -25,6 +25,7 @@ public class FormBody implements StepBody {
     private FormStep step;
     private StepResult<StepResult> result;
     private ViewGroup parent;
+    private static final String CONSENT_ID_FORM = "user_info_form";
 
     //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
     // View Fields
@@ -56,7 +57,7 @@ public class FormBody implements StepBody {
                 View bodyView = stepBody.getBodyView(VIEW_TYPE_COMPACT, inflater, body);
                 body.addView(bodyView);
 
-                if (i < questionSteps.size() - 1) {
+                if (i < questionSteps.size() - 1 && !step.getIdentifier().equals(CONSENT_ID_FORM)) {
                     body.addView(getDividerView(inflater, body));
                 }
             }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/TextQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/TextQuestionBody.java
@@ -1,15 +1,15 @@
 package org.researchstack.backbone.ui.step.body;
 
+import android.content.Context;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
 import com.google.android.material.textfield.TextInputLayout;
 
 import org.researchstack.backbone.R;
@@ -27,6 +27,7 @@ public class TextQuestionBody implements StepBody {
     //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
     private QuestionStep step;
     private StepResult<String> result;
+    private Context context;
 
     //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
     // View Fields
@@ -41,20 +42,10 @@ public class TextQuestionBody implements StepBody {
     @Override
     public View getBodyView(int viewType, LayoutInflater inflater, ViewGroup parent) {
         View body = inflater.inflate(R.layout.rsb_item_edit_text_compact, parent, false);
-
+        context = body.getContext();
         textEntry = body.findViewById(R.id.value);
-        if (step.getPlaceholder() != null) {
-            textEntry.getEditText().setHint(step.getPlaceholder());
-        } else {
-            textEntry.getEditText().setHint(LocalizationUtils.getLocalizedString(inflater.getContext(),R.string.rsb_hint_step_body_text));
-        }
-
-        TextView title = body.findViewById(R.id.label);
-
         if (viewType == VIEW_TYPE_COMPACT) {
-            title.setText(step.getTitle());
-        } else {
-            title.setVisibility(View.GONE);
+            textEntry.setHint(step.getTitle());
         }
 
         // Restore previous result
@@ -77,6 +68,10 @@ public class TextQuestionBody implements StepBody {
 
             @Override
             public void afterTextChanged(final Editable s) {
+                if (textEntry.isErrorEnabled()) {
+                    textEntry.setErrorEnabled(false);
+                    textEntry.getEditText().setTextColor(ContextCompat.getColor(context, R.color.black_87));
+                }
                 result.setResult(s.toString());
             }
         });
@@ -112,6 +107,8 @@ public class TextQuestionBody implements StepBody {
     public BodyAnswer getBodyAnswerState() {
         TextAnswerFormat format = (TextAnswerFormat) step.getAnswerFormat();
         if (!format.isAnswerValid(textEntry.getEditText().getText().toString())) {
+            textEntry.setError(LocalizationUtils.getLocalizedString(context, R.string.rsb_consent_text_question_error));
+            textEntry.getEditText().setTextColor(ContextCompat.getColor(context, R.color.red_scarlet));
             return BodyAnswer.INVALID;
         }
 

--- a/backbone/src/main/res/layout/rsb_item_edit_text_compact.xml
+++ b/backbone/src/main/res/layout/rsb_item_edit_text_compact.xml
@@ -7,39 +7,27 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:filterTouchesWhenObscured="true">
 
-    <TextView
-        android:id="@+id/label"
-        style="@style/TextStyle4"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        android:layout_marginStart="@dimen/rsb_margin_left"
-        android:layout_marginEnd="@dimen/rsb_margin_right"
-        android:layout_marginTop="@dimen/rsb_margin_top"
-        tools:text="title"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/value"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/label"
         android:layout_marginStart="@dimen/rsb_margin_left"
         android:layout_marginEnd="@dimen/rsb_margin_right"
-        android:layout_marginTop="@dimen/rsb_margin_top"
-        android:paddingBottom="@dimen/rsb_padding_medium"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+        android:layout_marginTop="20dp"
+        app:boxStrokeErrorColor="@color/red_scarlet"
+        app:errorIconTint="@color/red_scarlet"
+        app:errorTextColor="@color/red_scarlet"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.textfield.TextInputEditText
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/black_87"
             android:padding="@dimen/rsb_padding_medium"
-            />
+            android:textColor="@color/black_87" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/backbone/src/main/res/values-b+es+419/strings.xml
+++ b/backbone/src/main/res/values-b+es+419/strings.xml
@@ -145,4 +145,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Ingrese una hora válida</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Escribe a tiempo</string>
 
+    <string name="rsb_consent_text_question_error">[es-419]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-bg-rBG/strings.xml
+++ b/backbone/src/main/res/values-bg-rBG/strings.xml
@@ -161,4 +161,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Въведете валидно време</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Въведете време</string>
 
+    <string name="rsb_consent_text_question_error">[bg-BG]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-cs-rCZ/strings.xml
+++ b/backbone/src/main/res/values-cs-rCZ/strings.xml
@@ -152,4 +152,5 @@
     <string name="time_picker_header_text" tools:override="true"  tools:ignore="ResourceName">Nastavit čas</string>
     <string name="time_picker_input_error" tools:override="true" tools:ignore="ResourceName">Zadejte platný čas</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Zadejte čas</string>
+    <string name="rsb_consent_text_question_error">[cs-rCZ]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-da-rDK/strings.xml
+++ b/backbone/src/main/res/values-da-rDK/strings.xml
@@ -152,4 +152,6 @@
     <string name="time_picker_header_text" tools:ignore="ResourceName" tools:override="true">Fastsat tidspunkt</string>
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Indtast et gyldigt tidspunkt</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Skriv tid</string>
+
+    <string name="rsb_consent_text_question_error">[da-rDK]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-de-rCH/strings.xml
+++ b/backbone/src/main/res/values-de-rCH/strings.xml
@@ -153,4 +153,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Geben Sie eine gültige Zeit ein</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Geben Sie die Zeit ein</string>
 
+    <string name="rsb_consent_text_question_error">[de-rCH]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-de-rDE/strings.xml
+++ b/backbone/src/main/res/values-de-rDE/strings.xml
@@ -153,4 +153,6 @@
     <string name="time_picker_header_text" tools:ignore="ResourceName" tools:override="true">Zeit einstellen</string>
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Geben Sie eine gültige Zeit ein</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Geben Sie die Zeit ein</string>
+
+    <string name="rsb_consent_text_question_error">[de-rDE]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-en-rAU/strings.xml
+++ b/backbone/src/main/res/values-en-rAU/strings.xml
@@ -153,4 +153,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Enter a valid time</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Type in time</string>
 
+    <string name="rsb_consent_text_question_error">[en-rAU]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-en-rGB/strings.xml
+++ b/backbone/src/main/res/values-en-rGB/strings.xml
@@ -153,4 +153,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Enter a valid time</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Type in time</string>
 
+    <string name="rsb_consent_text_question_error">[en-rGB]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-en-rNZ/strings.xml
+++ b/backbone/src/main/res/values-en-rNZ/strings.xml
@@ -153,4 +153,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Enter a valid time</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Type in time</string>
 
+    <string name="rsb_consent_text_question_error">[en-rNZ]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-es-rES/strings.xml
+++ b/backbone/src/main/res/values-es-rES/strings.xml
@@ -157,4 +157,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Ingrese una hora válida</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Escribe a tiempo</string>
 
+    <string name="rsb_consent_text_question_error">[es-rES]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-es-rMX/strings.xml
+++ b/backbone/src/main/res/values-es-rMX/strings.xml
@@ -145,4 +145,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Ingrese una hora válida</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Escribe a tiempo</string>
 
+    <string name="rsb_consent_text_question_error">[es-rMX]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-es-rUS/strings.xml
+++ b/backbone/src/main/res/values-es-rUS/strings.xml
@@ -144,4 +144,6 @@
     <string name="time_picker_header_text" tools:ignore="ResourceName" tools:override="true">Fijar tiempo</string>
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Ingrese una hora válida</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Escribe a tiempo</string>
+
+    <string name="rsb_consent_text_question_error">[es-US]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-fr-rBE/strings.xml
+++ b/backbone/src/main/res/values-fr-rBE/strings.xml
@@ -153,4 +153,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Entrez une heure valide</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Tapez dans le temps</string>
 
+    <string name="rsb_consent_text_question_error">[fr-rBE]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-fr-rCA/strings.xml
+++ b/backbone/src/main/res/values-fr-rCA/strings.xml
@@ -153,4 +153,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Entrez une heure valide</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Tapez dans le temps</string>
 
+    <string name="rsb_consent_text_question_error">[fr-rCA]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-fr-rCH/strings.xml
+++ b/backbone/src/main/res/values-fr-rCH/strings.xml
@@ -153,4 +153,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Entrez une heure valide</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Tapez dans le temps</string>
 
+    <string name="rsb_consent_text_question_error">[fr-rCH]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-fr-rFR/strings.xml
+++ b/backbone/src/main/res/values-fr-rFR/strings.xml
@@ -153,4 +153,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Entrez une heure valide</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Tapez dans le temps</string>
 
+    <string name="rsb_consent_text_question_error">[fr-rFR]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-hu-rHU/strings.xml
+++ b/backbone/src/main/res/values-hu-rHU/strings.xml
@@ -155,4 +155,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Adjon meg egy érvényes időt</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Írja be az időt</string>
 
+    <string name="rsb_consent_text_question_error">[hu-rHU]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-it-rIT/strings.xml
+++ b/backbone/src/main/res/values-it-rIT/strings.xml
@@ -149,6 +149,8 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Inserisci un orario valido</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Digita l\'ora</string>
 
+    <string name="rsb_consent_text_question_error">[it-rIT]*Field Required</string>
+
     <!-- Material Time Picker Strings -->
 
 </resources>

--- a/backbone/src/main/res/values-ja-rJP/strings.xml
+++ b/backbone/src/main/res/values-ja-rJP/strings.xml
@@ -150,4 +150,6 @@
     <string name="time_picker_header_text" tools:ignore="ResourceName" tools:override="true">時間を設定する</string>
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">有効な時間を入力してください</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">時間を入力してください</string>
+
+    <string name="rsb_consent_text_question_error">[ja-rJP]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-ko-rKR/strings.xml
+++ b/backbone/src/main/res/values-ko-rKR/strings.xml
@@ -153,4 +153,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">유효한 시간을 입력하십시오</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">시간 입력</string>
 
+    <string name="rsb_consent_text_question_error">[ko-rKR]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-ms-rMY/strings.xml
+++ b/backbone/src/main/res/values-ms-rMY/strings.xml
@@ -154,4 +154,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Masukkan masa yang sah</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Taipkan masa</string>
 
+    <string name="rsb_consent_text_question_error">[ms-rMY]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-nl-rBE/strings.xml
+++ b/backbone/src/main/res/values-nl-rBE/strings.xml
@@ -147,4 +147,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Voer een geldige tijd in</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Voer tijd in</string>
 
+    <string name="rsb_consent_text_question_error">[nl-rBE]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-nl-rNL/strings.xml
+++ b/backbone/src/main/res/values-nl-rNL/strings.xml
@@ -147,4 +147,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Voer een geldige tijd in</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Voer tijd in</string>
 
+    <string name="rsb_consent_text_question_error">[nl-rNL]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-pl-rPL/strings.xml
+++ b/backbone/src/main/res/values-pl-rPL/strings.xml
@@ -157,4 +157,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Wprowadź prawidłowy czas</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Wpisz czas</string>
 
+    <string name="rsb_consent_text_question_error">[pl-PL]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-pt-rBR/strings.xml
+++ b/backbone/src/main/res/values-pt-rBR/strings.xml
@@ -154,4 +154,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Digite um horário válido</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Digite o horário</string>
 
+    <string name="rsb_consent_text_question_error">[pt-rBR]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-ru-rRU/strings.xml
+++ b/backbone/src/main/res/values-ru-rRU/strings.xml
@@ -151,4 +151,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Введите правильное время</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Введите время</string>
 
+    <string name="rsb_consent_text_question_error">[ru-rRU]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-ru-rUA/strings.xml
+++ b/backbone/src/main/res/values-ru-rUA/strings.xml
@@ -144,4 +144,6 @@
     <string name="time_picker_header_text" tools:ignore="ResourceName" tools:override="true">Установить время</string>
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Введите правильное время</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Введите время</string>
+
+    <string name="rsb_consent_text_question_error">[ru-rUA]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-sk-rSK/strings.xml
+++ b/backbone/src/main/res/values-sk-rSK/strings.xml
@@ -154,4 +154,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Zadajte platný čas</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Napíšte čas</string>
 
+    <string name="rsb_consent_text_question_error">[sk-rSK]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-sv-rSE/strings.xml
+++ b/backbone/src/main/res/values-sv-rSE/strings.xml
@@ -145,4 +145,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Ange en giltig tid</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Skriv in tid</string>
 
+    <string name="rsb_consent_text_question_error">[sv-rSE]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-ta-rIN/strings.xml
+++ b/backbone/src/main/res/values-ta-rIN/strings.xml
@@ -154,4 +154,6 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">சரியான நேரத்தை உள்ளிடவும்</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">நேரத்தை உள்ளிடவும்</string>
 
+    <string name="rsb_consent_text_question_error">[ta-rIN]*Field Required</string>
+
 </resources>

--- a/backbone/src/main/res/values-tr-rTR/strings.xml
+++ b/backbone/src/main/res/values-tr-rTR/strings.xml
@@ -144,4 +144,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Geçerli bir zaman girin</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Zamanı yazın</string>
 
+    <string name="rsb_consent_text_question_error">[tr-rTR]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-uk-rUA/strings.xml
+++ b/backbone/src/main/res/values-uk-rUA/strings.xml
@@ -144,4 +144,6 @@
     <string name="time_picker_header_text" tools:ignore="ResourceName" tools:override="true">Встановити час</string>
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Введіть дійсний час</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Введіть час</string>
+
+    <string name="rsb_consent_text_question_error">[uk-rUA]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-zh-rCN/strings.xml
+++ b/backbone/src/main/res/values-zh-rCN/strings.xml
@@ -147,4 +147,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">输入有效时间</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">输入时间</string>
 
+    <string name="rsb_consent_text_question_error">[zh-rCN]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values-zh-rTW/strings.xml
+++ b/backbone/src/main/res/values-zh-rTW/strings.xml
@@ -147,4 +147,5 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">輸入有效時間</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">輸入時間</string>
 
+    <string name="rsb_consent_text_question_error">[zh-rTW]*Field Required</string>
 </resources>

--- a/backbone/src/main/res/values/colors.xml
+++ b/backbone/src/main/res/values/colors.xml
@@ -69,4 +69,5 @@
     <color name="suggestion_bg">#e0e0e0</color>
     <color name="brownish_grey">#757575</color>
     <color name="pale_grey">#f7f8fa</color>
+    <color name="red_scarlet">#b00020</color>
 </resources>

--- a/backbone/src/main/res/values/strings.xml
+++ b/backbone/src/main/res/values/strings.xml
@@ -157,4 +157,7 @@
     <string name="time_picker_input_error" tools:ignore="ResourceName" tools:override="true">Enter a valid time</string>
     <string name="time_picker_prompt_label" tools:ignore="ResourceName" tools:override="true">Type in time</string>
 
+
+    <string name="rsb_consent_text_question_error">*Field Required</string>
+
 </resources>


### PR DESCRIPTION
**Branches**

- PAT: development
- Axon: development
- Cortex: development
- RS: task/PATAND-328

**Credentials**

- Environment: QA
- Org: hybridstudy
- Study: ML or QA

**Scenario**
* Open Pat
* Start consent
* Reach Form step, it should match [this](https://app.zeplin.io/project/5dc576e8f5b84283ac09b02a/screen/5f0e101b85a97b8efc9b9c10) 

