### PR TITLE
PATAND-348: Fix Showing full title for Form steps in ReviewStep

### DIFF
--- a/backbone/src/main/res/layout/rsb_form_step_layout.xml
+++ b/backbone/src/main/res/layout/rsb_form_step_layout.xml
@@ -13,7 +13,6 @@
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/rsb_reviewStep_item_bottom_margin_form"
         android:layout_marginStart="@dimen/rsb_reviewStep_item_margin_form"
-        app:layout_constrainedHeight="true"
         app:layout_constraintBottom_toTopOf="@id/formStepSkipped"
         app:layout_constraintEnd_toEndOf="@id/reviewStepEditButtonStartBarrier"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Objective
- Fixed PATAND-348: Showing full title for Form steps in ReviewStep

## How/Why?
When we first created ReviewStep, we added the line `app:layout_constrainedHeight="true"` to most of the view holder's layout views, basically it was added to make sure the edit button does not overlap with the user answer, but for the form step this should not be the case since there is already another `Barrier` that prevents this from happening, so I'm just removing that line here.

## How To Test
### Credentials:
- Environment: Int-Dev
- Org: abdallahandela
- Study: Banadol

### Steps:
  1. Open the app and use the credentials above
  2. Join Study
  3. Take task `Html Form` (last one in the list)
  4. Skip the form step

### Expected:
The full step title should appear:
<img width="287" alt="Screen Shot 2020-07-15 at 9 09 31 PM" src="https://user-images.githubusercontent.com/54676990/87585538-8afc0400-c6df-11ea-8fbf-2aefa44275c2.png">



## Branches
- RS: bug/PATAND-348
- PAT, Axon, Cortex -> development

## Links
- https://jira.devops.medable.com/browse/PATAND-348

Closes PATAND-348