### PR TITLE
PATAND-328: Consent: design of Name insert screen is not correct 

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
     // Material components
-    implementation "com.google.android.material:material:1.1.0"
+    implementation "com.google.android.material:material:1.2.0-beta01"
 
     // Koin for Android
     implementation "org.koin:koin-android:$koinVersion"

--- a/backbone/src/main/res/layout/rsb_item_edit_text_compact.xml
+++ b/backbone/src/main/res/layout/rsb_item_edit_text_compact.xml
@@ -13,6 +13,7 @@
         android:layout_marginStart="@dimen/rsb_margin_left"
         android:layout_marginEnd="@dimen/rsb_margin_right"
         android:layout_marginTop="20dp"
+        app:boxStrokeErrorColor="@color/red_scarlet"
         app:errorIconTint="@color/red_scarlet"
         app:errorTextColor="@color/red_scarlet"
         app:layout_constraintEnd_toEndOf="parent"

--- a/backbone/src/main/res/layout/rsb_item_edit_text_compact.xml
+++ b/backbone/src/main/res/layout/rsb_item_edit_text_compact.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:filterTouchesWhenObscured="true">
-
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/value"
@@ -16,7 +13,6 @@
         android:layout_marginStart="@dimen/rsb_margin_left"
         android:layout_marginEnd="@dimen/rsb_margin_right"
         android:layout_marginTop="20dp"
-        app:boxStrokeErrorColor="@color/red_scarlet"
         app:errorIconTint="@color/red_scarlet"
         app:errorTextColor="@color/red_scarlet"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
This MR is to update the library version of com.google.android.material:material to 1.2.0-beta01 to avoid this because of [this](https://gitlab.medable.com/axon/android/sdk/pipelines/36356) CI error



**Branches**

- PAT: bug/PATAND-328
- Axon: bug/PATAND-328
- Cortex: development
- RS: bug/PATAND-328

**Credentials**

- Environment: QA
- Org: hybridstudy
- Study: ML or QA


**Scenario**

- Open Pat
- Start consent
- Reach consent Form step, it should match this

https://zpl.io/VDE3mpq
https://zpl.io/Vkq9lpg