### PR TITLE
Patand-372 : Fixing the skip button on edit step (for the form step)

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
@@ -12,6 +12,7 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.Theme;
 
+import org.jetbrains.annotations.NotNull;
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.ConsentDocumentStep;
@@ -92,6 +93,11 @@ public class ConsentDocumentStepLayout extends ConstraintLayout implements StepL
 
     @Override
     public void isEditView(boolean isEditView) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
+    @Override
+    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentDocumentStepLayout.java
@@ -97,7 +97,7 @@ public class ConsentDocumentStepLayout extends ConstraintLayout implements StepL
     }
 
     @Override
-    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
+    public void setStepResultTo(@NotNull StepResult originalResult) {
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.jetbrains.annotations.NotNull;
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.ConsentSignatureStep;
@@ -92,6 +93,11 @@ public class ConsentSignatureStepLayout extends ConstraintLayout implements Step
     @Override
     public StepResult getStepResult() {
         return result;
+    }
+
+    @Override
+    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
     }
 
     private void initializeStep() {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentSignatureStepLayout.java
@@ -96,7 +96,7 @@ public class ConsentSignatureStepLayout extends ConstraintLayout implements Step
     }
 
     @Override
-    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
+    public void setStepResultTo(@NotNull StepResult originalResult) {
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import org.jetbrains.annotations.NotNull;
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.model.ConsentSection;
 import org.researchstack.backbone.result.StepResult;
@@ -95,6 +96,11 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
     public StepResult getStepResult() {
         // This step doesn't have a result, so we're returning null instead
         return null;
+    }
+
+    @Override
+    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
+        // no-op : This step doesn't have a result
     }
 
     @Override

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
@@ -99,7 +99,7 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
     }
 
     @Override
-    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
+    public void setStepResultTo(@NotNull StepResult originalResult) {
         // no-op : This step doesn't have a result
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/FormStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/FormStepLayout.java
@@ -1,0 +1,8 @@
+package org.researchstack.backbone.ui.step.layout;
+
+import org.researchstack.backbone.result.StepResult;
+import org.researchstack.backbone.step.Step;
+
+public interface FormStepLayout extends StepLayout {
+    void revertAllChildren(StepResult result);
+}

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/FormStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/FormStepLayout.java
@@ -5,4 +5,5 @@ import org.researchstack.backbone.step.Step;
 
 public interface FormStepLayout extends StepLayout {
     void revertAllChildren(StepResult result);
+    Boolean isFormStep();
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/FormStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/FormStepLayout.java
@@ -1,9 +1,0 @@
-package org.researchstack.backbone.ui.step.layout;
-
-import org.researchstack.backbone.result.StepResult;
-import org.researchstack.backbone.step.Step;
-
-public interface FormStepLayout extends StepLayout {
-    void revertAllChildren(StepResult result);
-    Boolean isFormStep();
-}

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -8,6 +8,7 @@ import android.widget.TextView;
 
 import androidx.core.text.HtmlCompat;
 
+import org.jetbrains.annotations.NotNull;
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ResourcePathManager;
 import org.researchstack.backbone.result.StepResult;
@@ -69,6 +70,11 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
 
     @Override
     public void isEditView(boolean isEditView) {
+        // no-op: Only needed when the user is on edit mode inside regular steps
+    }
+
+    @Override
+    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/InstructionStepLayout.java
@@ -74,7 +74,7 @@ public class InstructionStepLayout extends FixedSubmitBarLayout implements StepL
     }
 
     @Override
-    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
+    public void setStepResultTo(@NotNull StepResult originalResult) {
         // no-op: Only needed when the user is on edit mode inside regular steps
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
@@ -2,6 +2,7 @@ package org.researchstack.backbone.ui.step.layout;
 
 import android.view.View;
 
+import org.jetbrains.annotations.NotNull;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.ui.callbacks.StepCallbacks;
@@ -30,4 +31,10 @@ public interface StepLayout {
      * @return StepResult for a step even if it's not yet saved
      */
     StepResult getStepResult();
+
+    /**
+     * A method to revert the current result to the original one. This is need for the edit step
+     * @param originalResult
+     */
+    void revertToOriginalStepResult(@NotNull StepResult originalResult);
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/StepLayout.java
@@ -33,8 +33,8 @@ public interface StepLayout {
     StepResult getStepResult();
 
     /**
-     * A method to revert the current result to the original one. This is need for the edit step
-     * @param originalResult
+     * Replaces the Step's existing result, with a new one. For FormSteps, each children (that has a response in the new result) will have its result replaced too.
+     * @param newResult The new result set
      */
-    void revertToOriginalStepResult(@NotNull StepResult originalResult);
+    void setStepResultTo(@NotNull StepResult newResult);
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -355,12 +355,18 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements FormStepLa
     @Override
     public void revertAllChildren(StepResult originalResult) {
         Map<String, Object> results = originalResult.getResults();
-        for(Map.Entry<String, Object> result : results.entrySet()) {
+        for (Map.Entry<String, Object> result : results.entrySet()) {
             String id = result.getKey();
             Object value = result.getValue();
             if (value instanceof StepResult) {
-                ((StepResult) stepResult.getResultForIdentifier(id)).setResult(((StepResult) value).getResult());
+                if (stepResult.getResultForIdentifier(id) != null)
+                    ((StepResult) stepResult.getResultForIdentifier(id)).setResult(((StepResult) value).getResult());
             }
         }
+    }
+
+    @Override
+    public Boolean isFormStep() {
+        return stepBody instanceof FormBody;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -166,9 +166,9 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
     }
 
     @Override
-    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
+    public void setStepResultTo(@NotNull StepResult originalResult) {
         if (isFormStep()) {
-            revertAllChildren(originalResult);
+            setFormStepChildrenResultsTo(originalResult);
         } else {
             stepResult.setResult(originalResult.getResult());
         }
@@ -362,8 +362,8 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         return stepBody;
     }
 
-    public void revertAllChildren(@NotNull StepResult originalResult) {
-        Map<String, Object> results = originalResult.getResults();
+    private void setFormStepChildrenResultsTo(@NotNull StepResult newChildrenResult) {
+        Map<String, Object> results = newChildrenResult.getResults();
         for (Map.Entry<String, Object> result : results.entrySet()) {
             String id = result.getKey();
             Object value = result.getValue();
@@ -375,7 +375,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         }
     }
 
-    public Boolean isFormStep() {
+    private Boolean isFormStep() {
         return stepBody instanceof FormBody;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -32,8 +32,9 @@ import org.researchstack.backbone.utils.LogExt;
 import org.researchstack.backbone.utils.TextUtils;
 
 import java.lang.reflect.Constructor;
+import java.util.Map;
 
-public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout {
+public class SurveyStepLayout extends FixedSubmitBarLayout implements FormStepLayout {
     public static final String TAG = SurveyStepLayout.class.getSimpleName();
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -349,5 +350,17 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
 
     public StepBody getStepBody() {
         return stepBody;
+    }
+
+    @Override
+    public void revertAllChildren(StepResult originalResult) {
+        Map<String, Object> results = originalResult.getResults();
+        for(Map.Entry<String, Object> result : results.entrySet()) {
+            String id = result.getKey();
+            Object value = result.getValue();
+            if (value instanceof StepResult) {
+                ((StepResult) stepResult.getResultForIdentifier(id)).setResult(((StepResult) value).getResult());
+            }
+        }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -15,6 +15,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.jetbrains.annotations.NotNull;
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.ResourcePathManager;
 import org.researchstack.backbone.result.StepResult;
@@ -34,7 +35,7 @@ import org.researchstack.backbone.utils.TextUtils;
 import java.lang.reflect.Constructor;
 import java.util.Map;
 
-public class SurveyStepLayout extends FixedSubmitBarLayout implements FormStepLayout {
+public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout {
     public static final String TAG = SurveyStepLayout.class.getSimpleName();
 
     //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -162,6 +163,15 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements FormStepLa
     @Override
     public StepResult getStepResult() {
         return stepBody.getStepResult(isSkipped);
+    }
+
+    @Override
+    public void revertToOriginalStepResult(@NotNull StepResult originalResult) {
+        if (isFormStep()) {
+            revertAllChildren(originalResult);
+        } else {
+            stepResult.setResult(originalResult.getResult());
+        }
     }
 
     public void initStepLayout() {
@@ -352,20 +362,19 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements FormStepLa
         return stepBody;
     }
 
-    @Override
-    public void revertAllChildren(StepResult originalResult) {
+    public void revertAllChildren(@NotNull StepResult originalResult) {
         Map<String, Object> results = originalResult.getResults();
         for (Map.Entry<String, Object> result : results.entrySet()) {
             String id = result.getKey();
             Object value = result.getValue();
             if (value instanceof StepResult) {
-                if (stepResult.getResultForIdentifier(id) != null)
+                if (stepResult.getResultForIdentifier(id) != null) {
                     ((StepResult) stepResult.getResultForIdentifier(id)).setResult(((StepResult) value).getResult());
+                }
             }
         }
     }
 
-    @Override
     public Boolean isFormStep() {
         return stepBody instanceof FormBody;
     }


### PR DESCRIPTION
## Objective
Fix the skip button when on an form step

## Branches
- PAT: development
- Axon: bug/PATAND-372_issue_when_editing_form_step
- RS: bug/PATAND-372_issue_when_editing_form_step
- Cortex: development

## SCENARIO: 

#### Credentials:
- Environment: QA
- Org: hybridstudy
- Study: QA - Regression
- matias.battaglia+4@medable.com/qpal1010
- Task : T08 - Form

#### Steps:
* open flask/ resumed it 
* Log in
* Start the task and do all the step
* On the review step edit a step
* Try to skip it then cancel the skip.
* Save the value

## Expected 
The previous value is keep and there is no error when trying to save it

Close PATAND-372