### PR TITLE
PATAND-400: Update Gradle Plug-in and Wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,7 @@ buildscript {
     }
 
     dependencies {
-        // change this to 1.5.x if you're not on Android Studio 2.0.0 beta
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "com.neenbedankt.gradle.plugins:android-apt:1.4"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
+android.useAndroidX=true
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 21 13:17:30 CEST 2019
+#Tue Aug 04 15:36:53 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
## Objective
* Upgrade the gradle Plug-In to 4.0.1 (from 3.x) in the `build.gradle` (and also update the accompanying `readme.md`) and the wrapper to the 6.1.1

## How to Test?
* Smoke app test, C.I. pipeline must pass.

## Branches
* All projects to `task/PATAND-400` or `development` as they get integrated.