### PR TITLE
PATAND-401: Updating Libraries

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -101,7 +101,7 @@ dependencies {
 
     // Android x
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
 

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -74,9 +74,9 @@ android {
 }
 
 dependencies {
-    def kotlinVersion = '1.3.70'
+    def kotlinVersion = '1.3.72'
     def koinVersion = '2.1.5'
-    def navVersion = '2.2.2'
+    def navVersion = '2.3.0'
     def coreTestingVersion = '2.1.0'
     def mockitoKotlinVersion = "2.2.0"
     def mockitoVersion = '3.2.4'
@@ -88,7 +88,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
     // Material components
-    implementation "com.google.android.material:material:1.2.0-beta01"
+    api "com.google.android.material:material:1.2.0"
 
     // Koin for Android
     implementation "org.koin:koin-android:$koinVersion"

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -75,7 +75,7 @@ android {
 
 dependencies {
     def kotlinVersion = '1.3.72'
-    def koinVersion = '2.1.5'
+    def koinVersion = '2.1.6'
     def navVersion = '2.3.0'
     def coreTestingVersion = '2.1.0'
     def mockitoKotlinVersion = "2.2.0"
@@ -92,11 +92,7 @@ dependencies {
 
     // Koin for Android
     implementation "org.koin:koin-android:$koinVersion"
-
-    // Koin Android ViewModel feature
-    implementation "org.koin:koin-android-viewmodel:$koinVersion"
-
-    // Koin Android X ViewModel feature
+    implementation "org.koin:koin-android-scope:$koinVersion"
     implementation "org.koin:koin-androidx-viewmodel:$koinVersion"
 
     // Navigation Component

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     def navVersion = '2.3.0'
     def coreTestingVersion = '2.1.0'
     def mockitoKotlinVersion = "2.2.0"
-    def mockitoVersion = '3.2.4'
+    def mockitoVersion = '3.4.6'
 
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 


### PR DESCRIPTION
## Objective
* Update dependencies to newer versions.

## Description
* Kotlin 1.7.70 -> 1.3.72
* Koin (all) 2.1.5 -> 2.1.6
* Navigation 2.2.2 -> 2.3.0
* Mockito Core: 3.2.4 -> 3.4.6
* AppCompat 1.1.0 -> 1.2.0
* Material design: 1.2.0-beta01 -> 1.2.0, made it `api` (to be available to Axon/PAT)
* Removed `org.koin:koin-android-viewmodel` which was duplicated (and wrong) with `...koin-androidx-viewmodel`.

### How To test This?
Run all unit tests, run the app, use things. You have the list of things that changed, think how to test involved things.

## Branches
* all projects to `task/PATAND-401` or `development` as we merge.
